### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 This Model Context Protocol (MCP) server enables you to interact with the RunPod REST API through Claude or other MCP-compatible clients.
 
+<a href="https://glama.ai/mcp/servers/@runpod/runpod-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@runpod/runpod-mcp/badge" alt="RunPod Server MCP server" />
+</a>
+
 ## Features
 
 The server provides tools for managing:


### PR DESCRIPTION
This PR adds a badge for the [RunPod MCP Server](https://glama.ai/mcp/servers/@runpod/runpod-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@runpod/runpod-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@runpod/runpod-mcp/badge" alt="RunPod Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.