### PR TITLE
feat: add GPU/datacenter discovery tools and template filters

### DIFF
--- a/.changeset/add-gpu-datacenter-tools.md
+++ b/.changeset/add-gpu-datacenter-tools.md
@@ -1,0 +1,5 @@
+---
+"@runpod/mcp-server": minor
+---
+
+Add list-gpu-types and list-data-centers tools using public GraphQL API for hardware and region discovery. Enhance list-templates with filter params (includeRunpodTemplates, includePublicTemplates, includeEndpointBoundTemplates). Add tool descriptions to create-pod and list-templates recommending Pytorch 2.8.0 as default template.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# Runpod MCP server
+
+This is the official Runpod MCP (Model Context Protocol) server, published to npm as `@runpod/mcp-server`. It allows LLMs to manage Runpod infrastructure through the MCP standard, including Pods, Serverless endpoints, templates, network volumes, and container registry authentications.
+
+## Documentation style
+
+Always use sentence case for headings and titles.
+
+Always use proper nouns when discussing specific Runpod products and features:
+- Runpod (never RunPod).
+- Pod/Pods (never lowercase "pod/pods").
+- Serverless (never lowercase "serverless").
+- Hub, Instant Clusters, Secure Cloud, Community Cloud, Tetra, Flash.
+- Apply proper noun styling only to text that the user will see, not things like image/documentation links.
+
+These are generic terms (use lowercase):
+- endpoint, worker, cluster, template, handler, fine-tune, network volume.
+
+Prefer using paragraphs to bullet points unless directly asked. When using bullet points, end each line with a period.
+
+## Architecture
+
+The server communicates with two separate Runpod API backends. The REST API at `https://rest.runpod.io/v1` handles all authenticated CRUD operations for Pods, endpoints, templates, network volumes, and container registry auths. It requires a `RUNPOD_API_KEY` environment variable. The GraphQL API at `https://api.runpod.io/graphql` is public and requires no authentication. It serves read-only discovery queries like GPU types and data centers.
+
+All tools and helpers live in `src/index.ts`. The build produces both an ESM output (`dist/index.mjs`) used by the `bin` field and for local development, and a CJS output (`dist/index.js`) for `require()` consumers. Because `package.json` has `"type": "module"`, always use `dist/index.mjs` when running locally with `node`.
+
+## Local development
+
+```bash
+pnpm install
+pnpm build
+```
+
+To point Claude Code to your local build:
+
+```bash
+claude mcp add runpod -s user \
+  -e RUNPOD_API_KEY=YOUR_API_KEY \
+  -- node /absolute/path/to/runpod-mcp/dist/index.mjs
+```
+
+After making changes, rebuild with `pnpm build`. If you are in an active Claude Code session, type `/mcp` to reconnect without restarting. You can also use `pnpm build:watch` for auto-rebuilding during development.
+
+## Adding tools
+
+Tools are registered with `server.tool()`. There are two signatures:
+
+```typescript
+// Without a description
+server.tool('tool-name', { ...zodParams }, async (params) => { ... });
+
+// With a description (recommended when LLM guidance helps)
+server.tool('tool-name', 'Description visible to the LLM', { ...zodParams }, async (params) => { ... });
+```
+
+Use kebab-case names matching the resource pattern: `list-pods`, `get-pod`, `create-pod`, `update-pod`, `delete-pod`. For REST-backed tools, use the `runpodRequest()` helper which handles auth headers, JSON parsing, and error responses. For GraphQL-backed tools, use the `graphqlRequest<T>()` helper which hits the public endpoint without authentication.
+
+Define parameters with Zod schemas, calling `.describe()` on each field and `.optional()` on non-required ones. Add a tool description string when the LLM benefits from guidance, such as recommending a default template. Keep descriptions concise and actionable.
+
+All tool handlers should return the same shape: `{ content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] }`.
+
+Tools are grouped by section comments in `src/index.ts` (infrastructure, Pod management, endpoint management, template management, network volume management, container registry auth). Add new tools in the appropriate section. If adding a new resource category, follow the same comment style.
+
+## Known issues
+
+DELETE endpoints in the Runpod REST API return 204 No Content with no body. The `runpodRequest()` helper handles this by checking `content-type` before parsing JSON, but MCP clients may still surface an "Unexpected end of JSON input" message. The operation succeeds regardless.
+
+Pod `publicIp` and `portMappings` fields are empty while the container is initializing. This is Runpod API behavior, not an MCP server bug. Pods need to be polled until they are fully running.
+
+## Changesets and versioning
+
+This project uses [changesets](https://github.com/changesets/changesets) for version management and npm publishing. Every PR that changes user-facing behavior needs a changeset, including new tools, modified tool params or descriptions, bug fixes in tool handlers, and changes to API request logic. Documentation-only changes, dev tooling changes, and test files do not need changesets.
+
+The interactive `npx changeset` command does not work in non-TTY environments like Claude Code. Create the changeset file manually instead:
+
+`.changeset/DESCRIPTIVE_NAME.md`
+```markdown
+---
+"@runpod/mcp-server": minor
+---
+
+Description of what changed and why.
+```
+
+Use `patch` for bug fixes, `minor` for new tools, params, or features, and `major` for breaking changes to existing tool interfaces.
+
+The `.changeset/` directory is in `.gitignore`, so you must use `git add -f` to stage changeset files.
+
+After merging to `main`, the changesets bot opens a "Version Packages" PR that bumps `package.json` and updates `CHANGELOG.md`. Merging that PR triggers `changeset publish` which pushes to npm as `@runpod/mcp-server`.
+
+## PR conventions
+
+Use branch names like `feat/description` or `fix/description`. Include one changeset per PR. Follow conventional commit messages: `feat: ...`, `fix: ...`, `chore: ...`. Include a test plan in the PR description listing what was manually verified.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,21 @@
-# Runpod MCP Server
+# Runpod MCP server
 [![smithery badge](https://smithery.ai/badge/@runpod/runpod-mcp-ts)](https://smithery.ai/server/@runpod/runpod-mcp-ts)
 
-This Model Context Protocol (MCP) server enables you to interact with the Runpod REST API through Claude or other MCP-compatible clients.
+This Model Context Protocol (MCP) server lets you manage Runpod infrastructure through any MCP-compatible client. It provides tools for working with Pods, Serverless endpoints, templates, network volumes, and container registry authentications.
 
-## Features
+## Quick start
 
-The server provides tools for managing:
+### Requirements
 
-- **Pods**: Create, list, get details, update, start, stop, and delete pods
-- **Endpoints**: Create, list, get details, update, and delete serverless endpoints
-- **Templates**: Create, list, get details, update, and delete templates
-- **Network Volumes**: Create, list, get details, update, and delete network volumes
-- **Container Registry Authentications**: Create, list, get details, and delete authentications
-
-## Quick Start
-
-### Prerequisites
-
-- Node.js 18 or higher
-- A Runpod account and API key ([get your API key](https://www.runpod.io/console/user/settings))
+- Node.js 18 or higher.
+- A Runpod account and API key ([get your API key](https://www.runpod.io/console/user/settings)).
 
 ### Running with npx
 
 You can run the server directly without installation:
 
 ```bash
-RUNPOD_API_KEY=your_api_key_here npx @runpod/mcp-server@latest
+RUNPOD_API_KEY=YOUR_API_KEY npx @runpod/mcp-server@latest
 ```
 
 ### Installing via Smithery
@@ -36,66 +26,214 @@ To install for Claude Desktop automatically via [Smithery](https://smithery.ai/s
 npx -y @smithery/cli install @runpod/runpod-mcp-ts --client claude
 ```
 
-## Setting up with Claude for Desktop
+## Setting up with your client
 
-1. Open Claude for Desktop
-2. Edit the config file:
-   - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-3. Add the server configuration:
+Most MCP clients use a JSON configuration file with the same general structure. The examples below show the npx approach (recommended for most users) and the local build approach (for development). Replace `YOUR_API_KEY` with your actual Runpod API key.
+
+### Claude Code
+
+Add the MCP server globally so it's available across all your projects:
+
+```bash
+claude mcp add runpod -s user \
+  -e RUNPOD_API_KEY=YOUR_API_KEY \
+  -- npx -y @runpod/mcp-server@latest
+```
+
+Or add it to a specific project (creates a `.mcp.json` file you can commit):
+
+```bash
+claude mcp add runpod -s project \
+  -e RUNPOD_API_KEY=YOUR_API_KEY \
+  -- npx -y @runpod/mcp-server@latest
+```
+
+Verify the server is connected with `claude mcp list`. If you're in an active session, type `/mcp` to reconnect without restarting.
+
+### Claude Desktop
+
+Edit the config file at `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json
 {
   "mcpServers": {
     "runpod": {
       "command": "npx",
-      "args": ["@runpod/mcp-server@latest"],
+      "args": ["-y", "@runpod/mcp-server@latest"],
       "env": {
-        "RUNPOD_API_KEY": "your_api_key_here"
+        "RUNPOD_API_KEY": "YOUR_API_KEY"
       }
     }
   }
 }
 ```
 
-4. Restart Claude for Desktop
+Restart Claude Desktop after saving.
 
-## Usage Examples
+### Cursor
 
-### List all pods
+Add the following to `.cursor/mcp.json` in your project directory, or `~/.cursor/mcp.json` for global access:
+
+```json
+{
+  "mcpServers": {
+    "runpod": {
+      "command": "npx",
+      "args": ["-y", "@runpod/mcp-server@latest"],
+      "env": {
+        "RUNPOD_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Windsurf
+
+Open Windsurf settings (Cmd+Shift+P → "Open Windsurf Settings"), navigate to the Cascade section, and enable MCP. Then edit `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "runpod": {
+      "command": "npx",
+      "args": ["-y", "@runpod/mcp-server@latest"],
+      "env": {
+        "RUNPOD_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### VS Code (GitHub Copilot)
+
+MCP works in VS Code's agent mode (requires VS Code 1.101+). Add the following to `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "mcpServers": {
+    "runpod": {
+      "command": "npx",
+      "args": ["-y", "@runpod/mcp-server@latest"],
+      "env": {
+        "RUNPOD_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Click the "Start" button next to the server entry to connect.
+
+### Cline
+
+Open Cline in VS Code, click the hamburger menu (☰), and go to MCP Servers. You can add servers through the marketplace or manually configure in Cline's settings using the same JSON structure shown above.
+
+### JetBrains IDEs
+
+Create a `mcp.json` file at `~/.junie/mcp.json` (global) or `.junie/mcp/` in your project:
+
+```json
+{
+  "mcpServers": {
+    "runpod": {
+      "command": "npx",
+      "args": ["-y", "@runpod/mcp-server@latest"],
+      "env": {
+        "RUNPOD_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Other clients
+
+This server uses stdio transport and works with any MCP-compatible client. The configuration pattern is the same across all clients — point the command to `npx` with `@runpod/mcp-server@latest` as the argument, and set `RUNPOD_API_KEY` in the environment. For a full list of MCP clients, see the [official MCP clients page](https://modelcontextprotocol.io/clients).
+
+## Using a local build
+
+If you want to run from a local clone of the repo (for development or to test unreleased changes):
+
+```bash
+git clone https://github.com/runpod/runpod-mcp.git
+cd runpod-mcp
+pnpm install
+pnpm build
+```
+
+Then replace the `command` and `args` in any of the configurations above with:
+
+```json
+{
+  "command": "node",
+  "args": ["/absolute/path/to/runpod-mcp/dist/index.mjs"]
+}
+```
+
+After making changes to the source, re-run `pnpm build` and restart or reconnect the MCP server for changes to take effect.
+
+## Usage examples
+
+### List all Pods
 
 ```
-Can you list all my Runpod pods?
+Can you list all my Runpod Pods?
 ```
 
-### Create a new pod
+### Create a new Pod
 
 ```
-Create a new Runpod pod with the following specifications:
+Create a new Runpod Pod with the following specifications:
 - Name: test-pod
 - Image: runpod/pytorch:2.1.0-py3.10-cuda11.8.0-devel-ubuntu22.04
 - GPU Type: NVIDIA GeForce RTX 4090
 - GPU Count: 1
 ```
 
-### Create a serverless endpoint
+### Create a Serverless endpoint
 
 ```
-Create a Runpod serverless endpoint with the following configuration:
+Create a Runpod Serverless endpoint with the following configuration:
 - Name: my-endpoint
 - Template ID: 30zmvf89kd
 - Minimum workers: 0
 - Maximum workers: 3
 ```
 
-## Security Considerations
+## Contributing
 
-This server requires your Runpod API key, which grants full access to your Runpod account. For security:
+To get started with local development, clone the repo and build:
 
-- Never share your API key
-- Be cautious about what operations you perform
-- Consider setting up a separate API key with limited permissions
-- Don't use this in a production environment without proper security measures
+```bash
+git clone https://github.com/runpod/runpod-mcp.git
+cd runpod-mcp
+pnpm install
+pnpm build
+```
+
+After making changes, rebuild with `pnpm build`. In Claude Code, type `/mcp` to reconnect to the updated server without restarting your session. You can also use `pnpm build:watch` for auto-rebuilding during development.
+
+All tools live in `src/index.ts`. The server uses two backends: the REST API (`runpodRequest()`) for authenticated CRUD operations, and the GraphQL API (`graphqlRequest()`) for public read-only queries like GPU types and data centers. Follow existing patterns when adding new tools — kebab-case names, Zod schemas with `.describe()`, and JSON stringified responses.
+
+This project uses [changesets](https://github.com/changesets/changesets) for versioning and npm publishing. Every PR with user-facing changes needs a changeset file at `.changeset/DESCRIPTIVE_NAME.md`:
+
+```markdown
+---
+"@runpod/mcp-server": minor
+---
+
+Description of what changed and why.
+```
+
+Use `patch` for bug fixes, `minor` for new tools or features, and `major` for breaking changes. The `.changeset/` directory is gitignored, so use `git add -f` to stage changeset files.
+
+See [CLAUDE.md](./CLAUDE.md) for the full development guide including architecture details, tool conventions, and known issues.
+
+## Security considerations
+
+This server requires your Runpod API key, which grants full access to your Runpod account. Never share your API key. Be cautious about what operations you perform, and consider setting up a separate API key with limited permissions. Do not use this in a production environment without proper security measures.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,7 +383,7 @@ server.tool(
 // Create Pod
 server.tool(
   'create-pod',
-  'Create a new GPU/CPU pod on RunPod. If the user does not specify a template or image, recommend the "Runpod Pytorch 2.8.0" template (ID: runpod-torch-v280, image: runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404) as the default starting point — it has the most up-to-date CUDA and PyTorch versions.',
+  'Create a new GPU/CPU pod on RunPod. If the user does not specify an image, recommend the "Runpod Pytorch 2.8.0" image (runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404) as the default — it has the most up-to-date CUDA and PyTorch versions.',
   {
     name: z.string().optional().describe('Name for the pod'),
     imageName: z.string().describe('Docker image to use'),


### PR DESCRIPTION
## Summary

- **New tools**: `list-gpu-types` and `list-data-centers` using RunPod's public GraphQL API — allows LLMs to discover available hardware and regions without requiring authentication
- **Enhanced `list-templates`**: Added `includeRunpodTemplates`, `includePublicTemplates`, and `includeEndpointBoundTemplates` filter params (was previously a no-params tool returning only user templates)
- **Tool descriptions**: Added LLM-facing descriptions to `create-pod` and `list-templates` recommending **Runpod Pytorch 2.8.0** (ID: `runpod-torch-v280`) as the default template
- **README**: Added local build instructions for Claude Code CLI and Claude Desktop

## New Tools

### `list-gpu-types`
Queries the public GraphQL endpoint (`api.runpod.io/graphql`) — no API key needed. Supports filters:
- `minMemoryGb` — filter by VRAM (e.g., 80 for A100/H100)
- `secureCloudOnly` / `communityCloudOnly` — cloud type filter
- `searchTerm` — name search (e.g., "4090")
- `includeUnavailable` — include out-of-stock GPUs (excluded by default)

Results are sorted by stock availability then VRAM.

### `list-data-centers`
Also uses the public GraphQL endpoint. Supports `region` filter (e.g., "Europe", "United States").

## Test plan

- [x] `list-gpu-types` basic call returns GPUs sorted by stock/VRAM
- [x] `list-gpu-types` filters (minMemoryGb, secureCloudOnly, communityCloudOnly, searchTerm, includeUnavailable)
- [x] `list-data-centers` basic call and region filter
- [x] `list-templates` with each filter flag and combinations
- [x] Tool descriptions visible to LLM for `create-pod` and `list-templates`
- [x] Local build via `dist/index.mjs` connects and responds
- [x] `create-pod` functional test (requires real resources)