### PR TITLE
chore: add prepublishOnly to build dist before npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev": "tsx src/index.ts",
     "changeset": "changeset",
     "changeset:version": "changeset version",
+    "prepublishOnly": "pnpm build",
     "changeset:publish": "changeset publish"
   },
   "exports": {


### PR DESCRIPTION
The `dist/` directory was missing from the `1.1.0` npm tarball because there was no build step before publish.

Adds `prepublishOnly: "pnpm build"` so dist is always built into the tarball before `npm publish` / `changeset publish` runs.

No code changes — single line in `package.json`.