### PR TITLE
Set a default value for `imageName` in the `create-pod` tool schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -433,7 +433,10 @@ server.tool(
   'Create a new GPU/CPU pod on RunPod. If the user does not specify an image, recommend the "Runpod Pytorch 2.8.0" image (runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404) as the default — it has the most up-to-date CUDA and PyTorch versions.',
   {
     name: z.string().optional().describe('Name for the pod'),
-    imageName: z.string().describe('Docker image to use'),
+    imageName: z
+     .string()
+     .default('runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404')
+     .describe('Docker image to use'),
     cloudType: z
       .enum(['SECURE', 'COMMUNITY'])
       .optional()


### PR DESCRIPTION
Dear maintainers,

Currently `imageName` is required, and the tool description tells the LLM to fall back to `runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404` when the user doesn't specify one.

 This is fragile — LLMs can hallucinate image names, pass empty strings, or drop the field entirely and trigger a validation error. Enforcing the default in the schema guarantees a valid call regardless of how well the model follows the description.