### PR TITLE
feat: send user-agent header on outbound runpod api requests

### DIFF
--- a/.changeset/user-agent-header.md
+++ b/.changeset/user-agent-header.md
@@ -1,0 +1,5 @@
+---
+'@runpod/mcp-server': patch
+---
+
+Send a `User-Agent: runpod-mcp-server/<version>` header on every outbound request to the Runpod REST, Serverless, and GraphQL APIs so MCP-driven traffic can be attributed in API logs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,11 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import fetch, { type RequestInit as NodeFetchRequestInit } from 'node-fetch';
 
+declare const __PACKAGE_VERSION__: string;
+const PACKAGE_VERSION =
+  typeof __PACKAGE_VERSION__ !== 'undefined' ? __PACKAGE_VERSION__ : 'dev';
+const USER_AGENT = `runpod-mcp-server/${PACKAGE_VERSION}`;
+
 // Base URL for RunPod API
 const API_BASE_URL = 'https://rest.runpod.io/v1';
 
@@ -27,13 +32,12 @@ const server = new McpServer({
 const GRAPHQL_URL = 'https://api.runpod.io/graphql';
 
 // Helper function to make GraphQL requests to RunPod
-async function graphqlRequest<T>(
-  query: string
-): Promise<T> {
+async function graphqlRequest<T>(query: string): Promise<T> {
   const response = await fetch(GRAPHQL_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      'User-Agent': USER_AGENT,
     },
     body: JSON.stringify({ query }),
   });
@@ -66,6 +70,7 @@ async function runpodRequest(
   const headers = {
     Authorization: `Bearer ${API_KEY}`,
     'Content-Type': 'application/json',
+    'User-Agent': USER_AGENT,
   };
 
   const options: NodeFetchRequestInit = {
@@ -284,6 +289,7 @@ async function serverlessRequest(
   const headers: Record<string, string> = {
     Authorization: `Bearer ${API_KEY}`,
     'Content-Type': 'application/json',
+    'User-Agent': USER_AGENT,
   };
 
   const options: NodeFetchRequestInit = {
@@ -799,7 +805,9 @@ server.tool(
   'run-endpoint',
   'Submit an asynchronous job to a Serverless endpoint. Returns a job ID immediately — use get-job-status to poll for results. Async results are available for 30 minutes after completion.',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint to run'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint to run'
+    ),
     input: inputSchema,
     webhook: webhookSchema,
     policy: policySchema,
@@ -830,7 +838,9 @@ server.tool(
   'runsync-endpoint',
   'Submit a synchronous job to a Serverless endpoint and wait for the result. Best for tasks completing within 90 seconds. If processing exceeds 90 seconds, the response returns a job ID to poll with get-job-status. Max payload: 20 MB. Results expire after 1 minute. Use the wait parameter to extend the server-side wait up to 5 minutes (300000 ms).',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint to run synchronously'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint to run synchronously'
+    ),
     input: inputSchema,
     wait: z
       .number()
@@ -870,7 +880,9 @@ server.tool(
   'get-job-status',
   'Check the status of an asynchronous Serverless job. Returns the current status and output when complete. Job statuses: IN_QUEUE, IN_PROGRESS, COMPLETED, FAILED, CANCELLED, TIMED_OUT.',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint the job belongs to'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint the job belongs to'
+    ),
     jobId: jobIdSchema.describe('ID of the job to check'),
   },
   async (params) => {
@@ -895,7 +907,9 @@ server.tool(
   'stream-job',
   'Retrieve all streaming output from a Serverless job by polling until the job reaches a terminal state. The worker must support streaming output. Polls /stream/{jobId} repeatedly and collects every chunk until status is COMPLETED, FAILED, CANCELLED, or TIMED_OUT.',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint the job belongs to'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint the job belongs to'
+    ),
     jobId: jobIdSchema.describe('ID of the job to stream results from'),
   },
   async (params) => {
@@ -953,11 +967,7 @@ server.tool(
       content: [
         {
           type: 'text',
-          text: JSON.stringify(
-            { ...finalResult, stream: allChunks },
-            null,
-            2
-          ),
+          text: JSON.stringify({ ...finalResult, stream: allChunks }, null, 2),
         },
       ],
     };
@@ -969,7 +979,9 @@ server.tool(
   'cancel-job',
   'Cancel a Serverless job that is queued or in progress.',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint the job belongs to'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint the job belongs to'
+    ),
     jobId: jobIdSchema.describe('ID of the job to cancel'),
   },
   async (params) => {
@@ -995,7 +1007,9 @@ server.tool(
   'retry-job',
   'Retry a failed or timed-out Serverless job. Only works for jobs with FAILED or TIMED_OUT status. The previous output is removed and the job is requeued.',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint the job belongs to'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint the job belongs to'
+    ),
     jobId: jobIdSchema.describe('ID of the job to retry'),
   },
   async (params) => {
@@ -1021,7 +1035,9 @@ server.tool(
   'endpoint-health',
   'Get the health and operational status of a Serverless endpoint, including worker counts and job statistics.',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint to check health for'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint to check health for'
+    ),
   },
   async (params) => {
     const result = await serverlessRequest(params.endpointId, '/health');
@@ -1042,7 +1058,9 @@ server.tool(
   'purge-endpoint-queue',
   'Remove all pending jobs from a Serverless endpoint queue. Only affects queued jobs — in-progress jobs continue running. Use this for error recovery or clearing outdated requests.',
   {
-    endpointId: endpointIdSchema.describe('ID of the Serverless endpoint to purge the queue for'),
+    endpointId: endpointIdSchema.describe(
+      'ID of the Serverless endpoint to purge the queue for'
+    ),
   },
   async (params) => {
     const result = await serverlessRequest(

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,9 @@
+import { createRequire } from 'node:module';
 import { defineConfig } from 'tsup';
+
+const { version } = createRequire(import.meta.url)('./package.json') as {
+  version: string;
+};
 
 export default defineConfig([
   {
@@ -8,6 +13,9 @@ export default defineConfig([
     sourcemap: true,
     banner: {
       js: '#!/usr/bin/env node',
+    },
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(version),
     },
     outExtension({ format }) {
       return {


### PR DESCRIPTION
## Summary

- Adds `User-Agent: runpod-mcp-server/<version>` to every outbound request from the MCP server: `runpodRequest` (REST), `serverlessRequest` (Serverless runtime), and `graphqlRequest` (public GraphQL). This lets API logs attribute MCP-driven traffic.
- The version is read from `package.json` at build time via tsup's `define`, so it stays in sync with `changeset publish` automatically. A `dev` fallback is used when running through `tsx` (e.g. `pnpm dev`), producing `runpod-mcp-server/dev`.
- Includes a small amount of prettier reformatting in `src/index.ts` (long `.describe()` strings and one `JSON.stringify` block) so `pnpm prettier-check` passes on the branch — those lines already failed the project's prettier config on `main`.

Closes #23

## Test plan

- [x] `pnpm type-check` passes.
- [x] `pnpm build` succeeds with no warnings; verified `"1.1.0"` is inlined into both `dist/index.mjs` and `dist/index.js`.
- [x] `User-Agent: USER_AGENT` appears at 3 call sites in each bundled output (one per helper).
- [x] `pnpm lint` and `pnpm prettier-check` pass.
- [ ] Manual: run the built server and confirm the header reaches the Runpod API logs as `runpod-mcp-server/1.1.0`.