### PR TITLE
fix(ci): pin pnpm to v10 to keep Node 18/20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

`pnpm/action-setup@v4` with `version: latest` started pulling pnpm 11, which requires Node 22.13+ and breaks both CI and release workflows. Pinning to v10 (what we run locally) restores the full Node 18/20/22 matrix and the npm publish path.

## What broke

- `test (18)`: pnpm refuses to install — "This version of pnpm requires at least Node.js v22.13".
- `test (20)`: pnpm crashes loading `node:sqlite` (a Node 22-only built-in).
- `test (22)`: cancelled when the others failed.
- `release.yml` runs on Node 20 → same crash on `pnpm install`. **Any npm publish since the pnpm 11 release has been failing.**

Saw it surface on #25's last CI run (`80f4b01`) — same failure will hit any new PR until this lands.

## What changes

Two `version: latest` → `version: 10` swaps, one in each workflow.

## Test plan

- [ ] CI on this PR passes all three Node matrix slots (18 / 20 / 22).
- [ ] After merge: rebase #25, expect green CI.

## Follow-up (not in this PR)

When we're ready to drop Node 18/20 support (it's EOL'd or about to be), bump the `engines.node` field in `package.json`, the README install snippet, and the CI matrix together, then unpin pnpm back to `latest`.