### PR TITLE
feat: guided MCP install wizard (add)

### DIFF
--- a/.changeset/mcp-add-wizard.md
+++ b/.changeset/mcp-add-wizard.md
@@ -1,0 +1,5 @@
+---
+"@runpod/mcp-server": minor
+---
+
+Add a guided install wizard. Running `npx @runpod/mcp-server@latest add` detects installed agents (Claude Code, Claude Desktop, Cursor, Windsurf, Visual Studio Code), lets you pick which to configure, and writes the MCP configuration for each. It offers two connection modes: a hosted mode that points the agent at the hosted server and authenticates with the "Sign in with Runpod" OAuth flow (no API key stored on disk), and a local mode that runs the server via npx with a `RUNPOD_API_KEY`. `remove` undoes the changes. Existing config files keep their formatting and comments.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ The server never holds a credential of its own and never shares one across users
 
 ## Quick start
 
+### Guided install
+
+The fastest way to get set up is the interactive installer. It detects the agents you have installed, asks which ones to configure, and writes the configuration for you:
+
+```bash
+npx @runpod/mcp-server@latest add
+```
+
+It supports Claude Code, Claude Desktop, Cursor, Windsurf, and Visual Studio Code, and offers two connection modes. The recommended mode points the agent at the hosted server and lets it authenticate with the "Sign in with Runpod" OAuth flow, so no API key is stored on disk. The local mode runs the server through `npx` and stores a `RUNPOD_API_KEY` in the agent's config. To undo the changes later, run `npx @runpod/mcp-server@latest remove`.
+
 ### Run locally with `npx`
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     }
   },
   "dependencies": {
+    "@clack/prompts": "^1.5.1",
     "@modelcontextprotocol/sdk": "^1.7.0",
+    "jsonc-parser": "^3.3.1",
     "node-fetch": "^3.3.2",
     "zod": "^3.22.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.5.1
+        version: 1.6.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.7.0
         version: 1.20.2
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -112,6 +118,14 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@1.4.2':
+    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.6.0':
+    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
+    engines: {node: '>= 20.12.0'}
 
   '@edge-runtime/format@2.2.1':
     resolution: {integrity: sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==}
@@ -1196,6 +1210,15 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -1444,6 +1467,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -1898,6 +1924,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -2295,6 +2324,18 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.2
       prettier: 2.8.8
+
+  '@clack/core@1.4.2':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.6.0':
+    dependencies:
+      '@clack/core': 1.4.2
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   '@edge-runtime/format@2.2.1': {}
 
@@ -3322,6 +3363,16 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -3578,6 +3629,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -3994,6 +4047,8 @@ snapshots:
   signal-exit@4.0.2: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -1,0 +1,320 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import * as jsonc from 'jsonc-parser';
+
+// The npm package and the name the server is registered under in client config.
+export const SERVER_NAME = 'runpod';
+export const NPM_PACKAGE = '@runpod/mcp-server@latest';
+
+// The hosted Streamable HTTP endpoint. Clients point here and authenticate with
+// the OAuth "Sign in with Runpod" flow — no API key is stored in their config.
+// Overridable so a non-production deployment can be targeted during testing.
+export const HOSTED_URL =
+  process.env.RUNPOD_MCP_URL ?? 'https://runpod-mcp.vercel.app/';
+
+// How the user wants the server wired up:
+// - local: run via npx on this machine, authenticated by an API key in the env.
+// - hosted: connect to the hosted HTTP server and sign in with Runpod (OAuth).
+export type AddMode =
+  | { kind: 'local'; apiKey: string }
+  | { kind: 'hosted'; url: string };
+
+export interface AddResult {
+  success: boolean;
+  message?: string;
+}
+
+export interface McpClient {
+  // Stable id used as the multiselect value.
+  id: string;
+  // Human-readable label shown in the picker.
+  name: string;
+  // True when the client appears to be installed on this machine.
+  detect(): Promise<boolean>;
+  // Write (or update) the Runpod server entry in the client's config.
+  add(mode: AddMode): Promise<AddResult>;
+  // Remove the Runpod server entry from the client's config.
+  remove(): Promise<AddResult>;
+  // Where the config lives, for display and manual fallback.
+  describeTarget(): string;
+}
+
+// The local stdio config: Runpod's MCP server runs via npx and reads the API
+// key from the environment.
+function localServerConfig(apiKey: string) {
+  return {
+    command: 'npx',
+    args: ['-y', NPM_PACKAGE],
+    env: { RUNPOD_API_KEY: apiKey },
+  };
+}
+
+// The hosted config. Clients with native remote-MCP support take the URL
+// directly (VS Code additionally needs `type: 'http'`); the rest reach the
+// hosted server through the `mcp-remote` stdio bridge, which also drives OAuth.
+function hostedServerConfig(
+  strategy: 'http' | 'mcp-remote',
+  serverProperty: string,
+  url: string
+) {
+  if (strategy === 'mcp-remote') {
+    return { command: 'npx', args: ['-y', 'mcp-remote', url] };
+  }
+  return serverProperty === 'servers' ? { type: 'http', url } : { url };
+}
+
+// Read, edit, and write a JSON config while preserving the user's existing
+// formatting and comments (jsonc). Creates the file and parent dirs if missing.
+function upsertJsonServer(
+  configPath: string,
+  serverProperty: string,
+  value: unknown
+): AddResult {
+  try {
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const content = fs.existsSync(configPath)
+      ? fs.readFileSync(configPath, 'utf8')
+      : '';
+    const edits = jsonc.modify(content, [serverProperty, SERVER_NAME], value, {
+      formattingOptions: { tabSize: 2, insertSpaces: true },
+    });
+    fs.writeFileSync(configPath, jsonc.applyEdits(content, edits), 'utf8');
+    return { success: true };
+  } catch (error) {
+    return { success: false, message: errMessage(error) };
+  }
+}
+
+function removeJsonServer(
+  configPath: string,
+  serverProperty: string
+): AddResult {
+  try {
+    if (!fs.existsSync(configPath)) {
+      return { success: true, message: 'nothing to remove' };
+    }
+    const content = fs.readFileSync(configPath, 'utf8');
+    const edits = jsonc.modify(
+      content,
+      [serverProperty, SERVER_NAME],
+      undefined,
+      { formattingOptions: { tabSize: 2, insertSpaces: true } }
+    );
+    fs.writeFileSync(configPath, jsonc.applyEdits(content, edits), 'utf8');
+    return { success: true };
+  } catch (error) {
+    return { success: false, message: errMessage(error) };
+  }
+}
+
+function errMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function exists(p: string): boolean {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+// A JSON-config client that differs only in config path, server property, and
+// how it reaches the hosted server.
+function jsonClient(opts: {
+  id: string;
+  name: string;
+  serverProperty?: string;
+  // Native HTTP support, or the `mcp-remote` bridge for stdio-only clients.
+  hostedStrategy?: 'http' | 'mcp-remote';
+  configPath: () => string;
+  detectPaths?: () => string[];
+}): McpClient {
+  const serverProperty = opts.serverProperty ?? 'mcpServers';
+  const hostedStrategy = opts.hostedStrategy ?? 'http';
+  return {
+    id: opts.id,
+    name: opts.name,
+    detect: () =>
+      Promise.resolve(
+        (opts.detectPaths?.() ?? [path.dirname(opts.configPath())]).some(exists)
+      ),
+    add: (mode) => {
+      const value =
+        mode.kind === 'local'
+          ? localServerConfig(mode.apiKey)
+          : hostedServerConfig(hostedStrategy, serverProperty, mode.url);
+      return Promise.resolve(
+        upsertJsonServer(opts.configPath(), serverProperty, value)
+      );
+    },
+    remove: () =>
+      Promise.resolve(removeJsonServer(opts.configPath(), serverProperty)),
+    describeTarget: () => opts.configPath(),
+  };
+}
+
+// Locate the Claude Code CLI binary across common install locations and PATH.
+function findClaudeBinary(): string | null {
+  const candidates = [
+    path.join(os.homedir(), '.claude', 'local', 'claude'),
+    '/usr/local/bin/claude',
+    '/opt/homebrew/bin/claude',
+  ];
+  for (const candidate of candidates) {
+    if (exists(candidate)) return candidate;
+  }
+  try {
+    execSync('command -v claude', { stdio: 'pipe' });
+    return 'claude';
+  } catch {
+    return null;
+  }
+}
+
+function runClaude(binary: string, args: string[]): AddResult {
+  try {
+    execSync(`${binary} ${args.map((a) => JSON.stringify(a)).join(' ')}`, {
+      stdio: 'pipe',
+    });
+    return { success: true };
+  } catch (error) {
+    const message = errMessage(error);
+    // Re-running the wizard should be idempotent, not an error.
+    if (message.includes('already exists')) {
+      return { success: true, message: 'already configured' };
+    }
+    return { success: false, message };
+  }
+}
+
+// Claude Code manages its own config, so we drive its CLI rather than writing
+// files directly. This mirrors the documented `claude mcp add` command.
+const claudeCodeClient: McpClient = {
+  id: 'claude-code',
+  name: 'Claude Code',
+  detect: () => Promise.resolve(findClaudeBinary() !== null),
+  add: (mode) => {
+    const binary = findClaudeBinary();
+    if (!binary) {
+      return Promise.resolve({
+        success: false,
+        message: 'claude CLI not found',
+      });
+    }
+    const args =
+      mode.kind === 'local'
+        ? [
+            'mcp',
+            'add',
+            SERVER_NAME,
+            '--scope',
+            'user',
+            '-e',
+            `RUNPOD_API_KEY=${mode.apiKey}`,
+            '--',
+            'npx',
+            '-y',
+            NPM_PACKAGE,
+          ]
+        : [
+            'mcp',
+            'add',
+            '--transport',
+            'http',
+            '--scope',
+            'user',
+            SERVER_NAME,
+            mode.url,
+          ];
+    return Promise.resolve(runClaude(binary, args));
+  },
+  remove: () => {
+    const binary = findClaudeBinary();
+    if (!binary) {
+      return Promise.resolve({
+        success: false,
+        message: 'claude CLI not found',
+      });
+    }
+    try {
+      execSync(`${binary} mcp remove --scope user ${SERVER_NAME}`, {
+        stdio: 'pipe',
+      });
+      return Promise.resolve({ success: true });
+    } catch (error) {
+      return Promise.resolve({ success: true, message: errMessage(error) });
+    }
+  },
+  describeTarget: () => 'Claude Code user config (via `claude mcp` CLI)',
+};
+
+const home = os.homedir();
+const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
+
+// Claude Desktop stores its config in an OS-specific location.
+function claudeDesktopConfigPath(): string {
+  if (process.platform === 'win32') {
+    return path.join(appData, 'Claude', 'claude_desktop_config.json');
+  }
+  return path.join(
+    home,
+    'Library',
+    'Application Support',
+    'Claude',
+    'claude_desktop_config.json'
+  );
+}
+
+// VS Code uses a `servers` property (not `mcpServers`) in a per-user mcp.json.
+function vsCodeConfigPath(): string {
+  if (process.platform === 'win32') {
+    return path.join(appData, 'Code', 'User', 'mcp.json');
+  }
+  if (process.platform === 'darwin') {
+    return path.join(
+      home,
+      'Library',
+      'Application Support',
+      'Code',
+      'User',
+      'mcp.json'
+    );
+  }
+  return path.join(home, '.config', 'Code', 'User', 'mcp.json');
+}
+
+export const CLIENTS: McpClient[] = [
+  claudeCodeClient,
+  jsonClient({
+    id: 'cursor',
+    name: 'Cursor',
+    configPath: () => path.join(home, '.cursor', 'mcp.json'),
+  }),
+  jsonClient({
+    id: 'windsurf',
+    name: 'Windsurf',
+    // Windsurf is stdio-only, so it reaches the hosted server via mcp-remote.
+    hostedStrategy: 'mcp-remote',
+    configPath: () =>
+      path.join(home, '.codeium', 'windsurf', 'mcp_config.json'),
+  }),
+  jsonClient({
+    id: 'claude-desktop',
+    name: 'Claude Desktop',
+    // Claude Desktop config files are stdio-only; use the mcp-remote bridge.
+    hostedStrategy: 'mcp-remote',
+    configPath: claudeDesktopConfigPath,
+    // Detect by the application/support directory, which exists once the app runs.
+    detectPaths: () => [path.dirname(claudeDesktopConfigPath())],
+  }),
+  jsonClient({
+    id: 'vscode',
+    name: 'Visual Studio Code',
+    serverProperty: 'servers',
+    configPath: vsCodeConfigPath,
+    detectPaths: () => [path.dirname(vsCodeConfigPath())],
+  }),
+];

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import * as jsonc from 'jsonc-parser';
 
 // The npm package and the name the server is registered under in client config.
@@ -42,13 +42,15 @@ export interface McpClient {
 }
 
 // The local stdio config: Runpod's MCP server runs via npx and reads the API
-// key from the environment.
-function localServerConfig(apiKey: string) {
-  return {
+// key from the environment. VS Code's `servers` map requires an explicit
+// transport type for stdio servers (mcpServers-style clients infer it).
+function localServerConfig(apiKey: string, serverProperty: string) {
+  const config = {
     command: 'npx',
     args: ['-y', NPM_PACKAGE],
     env: { RUNPOD_API_KEY: apiKey },
   };
+  return serverProperty === 'servers' ? { type: 'stdio', ...config } : config;
 }
 
 // The hosted config. Clients with native remote-MCP support take the URL
@@ -144,7 +146,7 @@ function jsonClient(opts: {
     add: (mode) => {
       const value =
         mode.kind === 'local'
-          ? localServerConfig(mode.apiKey)
+          ? localServerConfig(mode.apiKey, serverProperty)
           : hostedServerConfig(hostedStrategy, serverProperty, mode.url);
       return Promise.resolve(
         upsertJsonServer(opts.configPath(), serverProperty, value)
@@ -176,9 +178,9 @@ function findClaudeBinary(): string | null {
 
 function runClaude(binary: string, args: string[]): AddResult {
   try {
-    execSync(`${binary} ${args.map((a) => JSON.stringify(a)).join(' ')}`, {
-      stdio: 'pipe',
-    });
+    // execFileSync (no shell) — args pass directly, so an API key with shell
+    // metacharacters can't be interpreted by a shell.
+    execFileSync(binary, args, { stdio: 'pipe' });
     return { success: true };
   } catch (error) {
     const message = errMessage(error);
@@ -240,7 +242,7 @@ const claudeCodeClient: McpClient = {
       });
     }
     try {
-      execSync(`${binary} mcp remove --scope user ${SERVER_NAME}`, {
+      execFileSync(binary, ['mcp', 'remove', '--scope', 'user', SERVER_NAME], {
         stdio: 'pipe',
       });
       return Promise.resolve({ success: true });

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -12,7 +12,7 @@ export const NPM_PACKAGE = '@runpod/mcp-server@latest';
 // the OAuth "Sign in with Runpod" flow — no API key is stored in their config.
 // Overridable so a non-production deployment can be targeted during testing.
 export const HOSTED_URL =
-  process.env.RUNPOD_MCP_URL ?? 'https://runpod-mcp.vercel.app/';
+  process.env.RUNPOD_MCP_URL ?? 'https://mcp.getrunpod.io/';
 
 // How the user wants the server wired up:
 // - local: run via npx on this machine, authenticated by an API key in the env.

--- a/src/install/wizard.ts
+++ b/src/install/wizard.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as p from '@clack/prompts';
 import {
   CLIENTS,
@@ -11,14 +11,16 @@ const API_KEYS_URL = 'https://www.runpod.io/console/user/settings';
 
 // Open a URL in the user's default browser. Best-effort and non-fatal.
 function openBrowser(url: string): void {
-  const command =
-    process.platform === 'darwin'
-      ? 'open'
-      : process.platform === 'win32'
-        ? 'start ""'
-        : 'xdg-open';
   try {
-    execSync(`${command} ${JSON.stringify(url)}`, { stdio: 'ignore' });
+    // No shell: pass the URL as a literal arg. On Windows the opener is the cmd
+    // built-in `start` (first quoted arg is the window title, hence the empty '').
+    if (process.platform === 'darwin') {
+      execFileSync('open', [url], { stdio: 'ignore' });
+    } else if (process.platform === 'win32') {
+      execFileSync('cmd', ['/c', 'start', '', url], { stdio: 'ignore' });
+    } else {
+      execFileSync('xdg-open', [url], { stdio: 'ignore' });
+    }
   } catch {
     // Ignore — the user can open the URL manually.
   }
@@ -29,7 +31,8 @@ function openBrowser(url: string): void {
 // (offline, etc.) so we can warn without blocking.
 async function verifyApiKey(apiKey: string): Promise<boolean | null> {
   try {
-    const response = await fetch('https://rest.runpod.io/v1/pods', {
+    const base = process.env.RUNPOD_REST_API_URL ?? 'https://rest.runpod.io/v1';
+    const response = await fetch(`${base}/pods`, {
       headers: { Authorization: `Bearer ${apiKey}` },
     });
     if (response.ok) return true;
@@ -201,7 +204,7 @@ async function runRemove(): Promise<void> {
   p.outro('Done.');
 }
 
-// Entry point for `npx @runpod/mcp-server mcp <add|remove>`.
+// Entry point for `npx @runpod/mcp-server <add|remove>`.
 export async function runWizard(subcommand: string): Promise<void> {
   p.intro('Runpod MCP server installer');
 

--- a/src/install/wizard.ts
+++ b/src/install/wizard.ts
@@ -1,0 +1,213 @@
+import { execSync } from 'child_process';
+import * as p from '@clack/prompts';
+import {
+  CLIENTS,
+  HOSTED_URL,
+  type AddMode,
+  type McpClient,
+} from './clients.js';
+
+const API_KEYS_URL = 'https://www.runpod.io/console/user/settings';
+
+// Open a URL in the user's default browser. Best-effort and non-fatal.
+function openBrowser(url: string): void {
+  const command =
+    process.platform === 'darwin'
+      ? 'open'
+      : process.platform === 'win32'
+        ? 'start ""'
+        : 'xdg-open';
+  try {
+    execSync(`${command} ${JSON.stringify(url)}`, { stdio: 'ignore' });
+  } catch {
+    // Ignore — the user can open the URL manually.
+  }
+}
+
+// Verify the API key works by calling a read-only REST endpoint. Returns true
+// on success, false on auth failure, and null when the check itself failed
+// (offline, etc.) so we can warn without blocking.
+async function verifyApiKey(apiKey: string): Promise<boolean | null> {
+  try {
+    const response = await fetch('https://rest.runpod.io/v1/pods', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (response.ok) return true;
+    if (response.status === 401 || response.status === 403) return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function bail(message = 'Cancelled.'): never {
+  p.cancel(message);
+  process.exit(0);
+}
+
+async function promptForApiKey(): Promise<string> {
+  const fromEnv = process.env.RUNPOD_API_KEY;
+  if (fromEnv) {
+    const useEnv = await p.confirm({
+      message: 'Use the RUNPOD_API_KEY from your environment?',
+    });
+    if (p.isCancel(useEnv)) bail();
+    if (useEnv) return fromEnv;
+  }
+
+  const create = await p.confirm({
+    message: 'Open the Runpod console to create or copy an API key?',
+  });
+  if (p.isCancel(create)) bail();
+  if (create) {
+    openBrowser(API_KEYS_URL);
+    p.log.info(`Opening ${API_KEYS_URL}`);
+  }
+
+  const apiKey = await p.password({
+    message: 'Paste your Runpod API key',
+    validate: (value) =>
+      !value || value.trim().length === 0
+        ? 'API key cannot be empty'
+        : undefined,
+  });
+  if (p.isCancel(apiKey)) bail();
+  return apiKey.trim();
+}
+
+async function selectClients(
+  detected: Map<string, boolean>,
+  verb: string
+): Promise<McpClient[]> {
+  const options = CLIENTS.map((client) => ({
+    value: client.id,
+    label: client.name,
+    hint: detected.get(client.id) ? 'detected' : undefined,
+  }));
+
+  const selected = await p.multiselect<string>({
+    message: `Which agents should we ${verb}?`,
+    options,
+    // Pre-select detected clients so the common case is a single Enter press.
+    initialValues: CLIENTS.filter((c) => detected.get(c.id)).map((c) => c.id),
+    required: true,
+  });
+  if (p.isCancel(selected)) bail();
+
+  return CLIENTS.filter((c) => selected.includes(c.id));
+}
+
+async function detectAll(): Promise<Map<string, boolean>> {
+  const entries = await Promise.all(
+    CLIENTS.map(async (c) => [c.id, await c.detect()] as const)
+  );
+  return new Map(entries);
+}
+
+// Ask how the server should be wired up, then collect what that mode needs.
+// Hosted is the default: the client signs in with Runpod over OAuth and no key
+// is ever written to disk. Local runs the server via npx with an API key.
+async function selectMode(): Promise<AddMode> {
+  const kind = await p.select({
+    message: 'How do you want to connect to Runpod?',
+    options: [
+      {
+        value: 'hosted',
+        label: 'Sign in with Runpod (recommended)',
+        hint: 'hosted, OAuth, no API key stored',
+      },
+      {
+        value: 'local',
+        label: 'Run locally with an API key',
+        hint: 'runs on this machine via npx',
+      },
+    ],
+    initialValue: 'hosted',
+  });
+  if (p.isCancel(kind)) bail();
+
+  if (kind === 'hosted') {
+    return { kind: 'hosted', url: HOSTED_URL };
+  }
+
+  const apiKey = await promptForApiKey();
+
+  const verifySpinner = p.spinner();
+  verifySpinner.start('Verifying API key');
+  const valid = await verifyApiKey(apiKey);
+  if (valid === true) {
+    verifySpinner.stop('API key verified.');
+  } else if (valid === false) {
+    verifySpinner.stop('API key rejected by Runpod.');
+    const proceed = await p.confirm({
+      message: 'The key did not authenticate. Continue anyway?',
+      initialValue: false,
+    });
+    if (p.isCancel(proceed) || !proceed) bail();
+  } else {
+    verifySpinner.stop('Could not verify the key (offline?). Continuing.');
+  }
+
+  return { kind: 'local', apiKey };
+}
+
+async function runAdd(): Promise<void> {
+  const detected = await detectAll();
+  const clients = await selectClients(detected, 'set up');
+  const mode = await selectMode();
+
+  const results: string[] = [];
+  for (const client of clients) {
+    const spinner = p.spinner();
+    spinner.start(`Configuring ${client.name}`);
+    const result = await client.add(mode);
+    if (result.success) {
+      spinner.stop(`${client.name} configured.`);
+      results.push(`✓ ${client.name} — ${client.describeTarget()}`);
+    } else {
+      spinner.stop(`${client.name} failed.`);
+      results.push(`✗ ${client.name} — ${result.message ?? 'unknown error'}`);
+    }
+  }
+
+  p.note(results.join('\n'), 'Results');
+  p.outro(
+    mode.kind === 'hosted'
+      ? 'Restart your agent, then complete "Sign in with Runpod" when it connects.'
+      : 'Restart your agent (or reconnect MCP) to load the Runpod tools.'
+  );
+}
+
+async function runRemove(): Promise<void> {
+  const detected = await detectAll();
+  const clients = await selectClients(detected, 'remove Runpod from');
+
+  const results: string[] = [];
+  for (const client of clients) {
+    const spinner = p.spinner();
+    spinner.start(`Removing from ${client.name}`);
+    const result = await client.remove();
+    spinner.stop(
+      result.success ? `${client.name} cleaned up.` : `${client.name} failed.`
+    );
+    results.push(
+      `${result.success ? '✓' : '✗'} ${client.name}${
+        result.message ? ` — ${result.message}` : ''
+      }`
+    );
+  }
+
+  p.note(results.join('\n'), 'Results');
+  p.outro('Done.');
+}
+
+// Entry point for `npx @runpod/mcp-server mcp <add|remove>`.
+export async function runWizard(subcommand: string): Promise<void> {
+  p.intro('Runpod MCP server installer');
+
+  if (subcommand === 'remove') {
+    await runRemove();
+  } else {
+    await runAdd();
+  }
+}

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -2,18 +2,34 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createServer } from './server.js';
 import { registerTools } from './tools.js';
 
-// Get API key from environment variable
-const API_KEY = process.env.RUNPOD_API_KEY;
-if (!API_KEY) {
-  console.error('RUNPOD_API_KEY environment variable is required');
-  process.exit(1);
+// Detect the install wizard subcommand (`add` / `remove`). In this mode we run
+// the interactive installer instead of starting the stdio server, and the API
+// key is collected by the wizard rather than required up front.
+const WIZARD_SUBCOMMANDS = ['add', 'remove'];
+const subcommand = process.argv[2];
+const isWizardMode = WIZARD_SUBCOMMANDS.includes(subcommand);
+
+if (isWizardMode) {
+  import('./install/wizard.js')
+    .then(({ runWizard }) => runWizard(subcommand))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+} else {
+  // Get API key from environment variable
+  const API_KEY = process.env.RUNPOD_API_KEY;
+  if (!API_KEY) {
+    console.error('RUNPOD_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  const server = createServer();
+
+  // Register all tools with the API key from the environment
+  registerTools(server, { apiKey: API_KEY, transport: 'stdio' });
+
+  // Start receiving messages on stdin and sending messages on stdout
+  const transport = new StdioServerTransport();
+  server.connect(transport);
 }
-
-const server = createServer();
-
-// Register all tools with the API key from the environment
-registerTools(server, { apiKey: API_KEY, transport: 'stdio' });
-
-// Start receiving messages on stdin and sending messages on stdout
-const transport = new StdioServerTransport();
-server.connect(transport);


### PR DESCRIPTION
## Summary

Adds a guided installer so users can set up the Runpod MCP server with one command (the CTA pattern PostHog ships):

```bash
npx @runpod/mcp-server@latest add
```

It detects installed agents (Claude Code, Claude Desktop, Cursor, Windsurf, Visual Studio Code), lets the user pick which to configure, and writes the MCP config for each. `remove` undoes it. Existing config files keep their formatting and comments (edited via `jsonc-parser`).

Two connection modes:

- **Sign in with Runpod (recommended)** — points the agent at the hosted server (`https://runpod-mcp.vercel.app/`, overridable via `RUNPOD_MCP_URL`) and lets it authenticate with the OAuth flow shipped in #27. No API key stored on disk. Wired natively for Cursor / VS Code / Claude Code, and through the `mcp-remote` bridge for stdio-only clients (Windsurf, Claude Desktop).
- **Local with API key** — runs the server via `npx` with `RUNPOD_API_KEY` in the agent config; the wizard helps grab and verify the key.

Routing lives in `src/stdio.ts`: bare `add` / `remove` lazy-load the wizard; normal server startup is unchanged. New code is in `src/install/` (`clients.ts`, `wizard.ts`), using `@clack/prompts` for the UI.

> Rebased onto `main` now that #27 (OAuth) has merged; supersedes the earlier stacked PR #28.

## Test plan

Verified:
- `pnpm build`, `type-check`, `lint`, `prettier-check` pass.
- `smoke:stdio` connects and invokes a tool over stdio (wizard routing doesn't regress the server).
- Wizard launches from the built `dist/stdio.mjs` bin; server mode still errors without `RUNPOD_API_KEY`.
- Config writing against an isolated `HOME` for both modes: correct shapes per client (Cursor native `url`, VS Code `servers`+`type:http`, Windsurf/Claude Desktop `mcp-remote`, local stdio+env), idempotent key updates, comment/sibling-server preservation on add and remove.

Not yet verified (needs the hosted console + backend deployed):
- Live end-to-end connect from each real client against the hosted endpoint, including OAuth sign-in and the `mcp-remote` bridge.

Kept as a **draft** until the hosted sign-in page/backend are deployed and a live smoke test passes. The local API-key mode works standalone today.