### PR TITLE
feat: cap list-tool responses + add test suite

### DIFF
--- a/.changeset/list-tools-pagination-token-caps.md
+++ b/.changeset/list-tools-pagination-token-caps.md
@@ -1,0 +1,15 @@
+---
+"@runpod/mcp-server": minor
+---
+
+Cap list-tool responses so they no longer overflow the agent's context window.
+Every `list-*` tool (`list-pods`, `list-endpoints`, `list-templates`,
+`list-network-volumes`, `list-container-registry-auths`) now accepts optional
+`limit` and `cursor` parameters and returns at most `limit` items (default 20,
+max 100) inside a `{ items, pagination }` envelope that reports `total`,
+`returned`, `truncated`, and a `nextCursor` for fetching the next page.
+
+The REST API does not yet support server-side pagination, so this is a
+client-side cap; the `limit`/`cursor` signature is shaped to match the
+cursor-based pagination the REST API will add, so the tool interface will not
+change when server-side pagination lands.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "clean": "rm -rf dist *.tsbuildinfo",
     "lint": "eslint \"./**/*.ts*\"",
     "type-check": "tsc --noEmit -p tsconfig.json",
+    "test": "node --import tsx --test tests/*.test.ts",
     "prettier-check": "prettier --check \"./**/*.ts*\"",
     "start": "node dist/stdio.mjs",
     "dev": "tsx src/stdio.ts",

--- a/scripts/smoke-list.ts
+++ b/scripts/smoke-list.ts
@@ -1,0 +1,63 @@
+// Live end-to-end check for the list-* pagination caps. Boots the stdio MCP
+// server as a subprocess, connects a real MCP client, calls each list tool,
+// and prints the pagination envelope so you can confirm the cap fires against
+// a real account.
+//
+//   RUNPOD_API_KEY=... tsx scripts/smoke-list.ts
+//
+// Requires a Runpod API key. Read-only: only calls list-* tools.
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const LIST_TOOLS = [
+  'list-pods',
+  'list-endpoints',
+  'list-templates',
+  'list-network-volumes',
+  'list-container-registry-auths',
+];
+
+async function main() {
+  const apiKey = process.env.RUNPOD_API_KEY;
+  if (!apiKey) throw new Error('RUNPOD_API_KEY is required');
+
+  const transport = new StdioClientTransport({
+    command: 'tsx',
+    args: ['src/stdio.ts'],
+    env: { ...process.env, RUNPOD_API_KEY: apiKey },
+  });
+
+  const client = new Client(
+    { name: 'smoke-list', version: '0.0.0' },
+    { capabilities: {} }
+  );
+  await client.connect(transport);
+
+  for (const name of LIST_TOOLS) {
+    // list-templates needs the include flag to surface the full catalog.
+    const args =
+      name === 'list-templates' ? { includeRunpodTemplates: true } : {};
+    const res = await client.callTool({ name, arguments: args });
+    const text = (res.content as Array<{ type: string; text: string }>)[0]
+      ?.text;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+    const pagination =
+      parsed && typeof parsed === 'object' && 'pagination' in parsed
+        ? (parsed as { pagination: unknown }).pagination
+        : '(no pagination envelope)';
+    console.log(`\n=== ${name} ===`);
+    console.log(JSON.stringify(pagination, null, 2));
+  }
+
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,0 +1,103 @@
+// ============== LIST RESULT PAGINATION / TOKEN CAPS ==============
+// The REST list endpoints do not yet support server-side pagination, so a
+// large account can return a payload many times the size of an LLM's context
+// window (e.g. list-templates has been observed at ~15x Claude Code's window),
+// which ends the agent session. Until the REST API ships cursor pagination,
+// the MCP caps list responses client-side: it returns at most `limit` items
+// and reports how many were omitted so the agent knows to narrow its query.
+//
+// The `limit` and `cursor` parameters are shaped to match the cursor-based
+// pagination the REST API will add, so the tool signatures do not change when
+// server-side pagination lands; the MCP will simply forward them and surface a
+// real `nextCursor` instead of the client-side offset used here.
+
+import { z } from 'zod';
+
+// Default and maximum number of items returned by a list tool in a single
+// call. The cap is what protects the agent's context; `limit` lets a caller
+// ask for fewer (or more, up to the ceiling) when they know what they want.
+export const DEFAULT_LIST_LIMIT = 20;
+export const MAX_LIST_LIMIT = 100;
+
+// Shared Zod parameters added to every list-* tool. Optional so existing
+// callers that pass nothing keep working (they get the default page).
+export const listPaginationParams = {
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_LIST_LIMIT)
+    .optional()
+    .describe(
+      `Maximum number of items to return (default ${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}). Use the returned nextCursor to fetch the next page.`
+    ),
+  cursor: z
+    .string()
+    .optional()
+    .describe(
+      'Opaque pagination cursor from a previous response (nextCursor). Omit to start from the beginning.'
+    ),
+};
+
+// Decodes the opaque cursor into a numeric offset. The cursor is currently a
+// base64-encoded offset; when the REST API ships real cursors this becomes a
+// passthrough. Invalid cursors are treated as the start so a bad value never
+// throws in an agent's face.
+export function decodeCursorOffset(cursor: string | undefined): number {
+  if (!cursor) return 0;
+  try {
+    const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+    const offset = Number.parseInt(decoded, 10);
+    return Number.isFinite(offset) && offset >= 0 ? offset : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function encodeCursorOffset(offset: number): string {
+  return Buffer.from(String(offset), 'utf8').toString('base64');
+}
+
+// Caps a list response to `limit` items starting at `cursor`, returning an
+// envelope that tells the agent how much it is seeing and how to get the rest.
+// Only arrays are paginated; any other shape is passed through untouched.
+export function capListResult(
+  result: unknown,
+  options: { limit?: number; cursor?: string }
+): { content: Array<{ type: 'text'; text: string }> } {
+  const limit = Math.min(options.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
+  const offset = decodeCursorOffset(options.cursor);
+
+  if (!Array.isArray(result)) {
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(result, null, 2) },
+      ],
+    };
+  }
+
+  const total = result.length;
+  const page = result.slice(offset, offset + limit);
+  const nextOffset = offset + page.length;
+  const hasMore = nextOffset < total;
+
+  const envelope = {
+    items: page,
+    pagination: {
+      total,
+      returned: page.length,
+      offset,
+      truncated: hasMore,
+      nextCursor: hasMore ? encodeCursorOffset(nextOffset) : null,
+      note: hasMore
+        ? `Showing ${page.length} of ${total}. Pass cursor=nextCursor to fetch more, or narrow the query with filters.`
+        : undefined,
+    },
+  };
+
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(envelope, null, 2) },
+    ],
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import fetch, { type RequestInit as NodeFetchRequestInit } from 'node-fetch';
 import { randomUUID } from 'node:crypto';
+import { capListResult, listPaginationParams } from './pagination.js';
 
 // Base URL for Runpod REST API. Override via RUNPOD_REST_API_URL to point at a
 // non-production environment (e.g. when authenticating with a dev API key).
@@ -115,108 +116,6 @@ async function graphqlRequest<T>(
   }
 
   return result.data;
-}
-
-// ============== LIST RESULT PAGINATION / TOKEN CAPS ==============
-// The REST list endpoints do not yet support server-side pagination, so a
-// large account can return a payload many times the size of an LLM's context
-// window (e.g. list-templates has been observed at ~15x Claude Code's window),
-// which ends the agent session. Until the REST API ships cursor pagination,
-// the MCP caps list responses client-side: it returns at most `limit` items
-// and reports how many were omitted so the agent knows to narrow its query.
-//
-// The `limit` and `cursor` parameters are shaped to match the cursor-based
-// pagination the REST API will add, so the tool signatures do not change when
-// server-side pagination lands; the MCP will simply forward them and surface a
-// real `nextCursor` instead of the client-side offset used here.
-
-// Default and maximum number of items returned by a list tool in a single
-// call. The cap is what protects the agent's context; `limit` lets a caller
-// ask for fewer (or more, up to the ceiling) when they know what they want.
-const DEFAULT_LIST_LIMIT = 20;
-const MAX_LIST_LIMIT = 100;
-
-// Shared Zod parameters added to every list-* tool. Optional so existing
-// callers that pass nothing keep working (they get the default page).
-const listPaginationParams = {
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(MAX_LIST_LIMIT)
-    .optional()
-    .describe(
-      `Maximum number of items to return (default ${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}). Use the returned nextCursor to fetch the next page.`
-    ),
-  cursor: z
-    .string()
-    .optional()
-    .describe(
-      'Opaque pagination cursor from a previous response (nextCursor). Omit to start from the beginning.'
-    ),
-};
-
-// Decodes the opaque cursor into a numeric offset. The cursor is currently a
-// base64-encoded offset; when the REST API ships real cursors this becomes a
-// passthrough. Invalid cursors are treated as the start so a bad value never
-// throws in an agent's face.
-function decodeCursorOffset(cursor: string | undefined): number {
-  if (!cursor) return 0;
-  try {
-    const decoded = Buffer.from(cursor, 'base64').toString('utf8');
-    const offset = Number.parseInt(decoded, 10);
-    return Number.isFinite(offset) && offset >= 0 ? offset : 0;
-  } catch {
-    return 0;
-  }
-}
-
-function encodeCursorOffset(offset: number): string {
-  return Buffer.from(String(offset), 'utf8').toString('base64');
-}
-
-// Caps a list response to `limit` items starting at `cursor`, returning an
-// envelope that tells the agent how much it is seeing and how to get the rest.
-// Only arrays are paginated; any other shape is passed through untouched.
-function capListResult(
-  result: unknown,
-  options: { limit?: number; cursor?: string }
-): { content: Array<{ type: 'text'; text: string }> } {
-  const limit = Math.min(options.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
-  const offset = decodeCursorOffset(options.cursor);
-
-  if (!Array.isArray(result)) {
-    return {
-      content: [
-        { type: 'text' as const, text: JSON.stringify(result, null, 2) },
-      ],
-    };
-  }
-
-  const total = result.length;
-  const page = result.slice(offset, offset + limit);
-  const nextOffset = offset + page.length;
-  const hasMore = nextOffset < total;
-
-  const envelope = {
-    items: page,
-    pagination: {
-      total,
-      returned: page.length,
-      offset,
-      truncated: hasMore,
-      nextCursor: hasMore ? encodeCursorOffset(nextOffset) : null,
-      note: hasMore
-        ? `Showing ${page.length} of ${total}. Pass cursor=nextCursor to fetch more, or narrow the query with filters.`
-        : undefined,
-    },
-  };
-
-  return {
-    content: [
-      { type: 'text' as const, text: JSON.stringify(envelope, null, 2) },
-    ],
-  };
 }
 
 // Helper function to make authenticated API requests to Runpod REST API

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -117,6 +117,108 @@ async function graphqlRequest<T>(
   return result.data;
 }
 
+// ============== LIST RESULT PAGINATION / TOKEN CAPS ==============
+// The REST list endpoints do not yet support server-side pagination, so a
+// large account can return a payload many times the size of an LLM's context
+// window (e.g. list-templates has been observed at ~15x Claude Code's window),
+// which ends the agent session. Until the REST API ships cursor pagination,
+// the MCP caps list responses client-side: it returns at most `limit` items
+// and reports how many were omitted so the agent knows to narrow its query.
+//
+// The `limit` and `cursor` parameters are shaped to match the cursor-based
+// pagination the REST API will add, so the tool signatures do not change when
+// server-side pagination lands; the MCP will simply forward them and surface a
+// real `nextCursor` instead of the client-side offset used here.
+
+// Default and maximum number of items returned by a list tool in a single
+// call. The cap is what protects the agent's context; `limit` lets a caller
+// ask for fewer (or more, up to the ceiling) when they know what they want.
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+// Shared Zod parameters added to every list-* tool. Optional so existing
+// callers that pass nothing keep working (they get the default page).
+const listPaginationParams = {
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_LIST_LIMIT)
+    .optional()
+    .describe(
+      `Maximum number of items to return (default ${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}). Use the returned nextCursor to fetch the next page.`
+    ),
+  cursor: z
+    .string()
+    .optional()
+    .describe(
+      'Opaque pagination cursor from a previous response (nextCursor). Omit to start from the beginning.'
+    ),
+};
+
+// Decodes the opaque cursor into a numeric offset. The cursor is currently a
+// base64-encoded offset; when the REST API ships real cursors this becomes a
+// passthrough. Invalid cursors are treated as the start so a bad value never
+// throws in an agent's face.
+function decodeCursorOffset(cursor: string | undefined): number {
+  if (!cursor) return 0;
+  try {
+    const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+    const offset = Number.parseInt(decoded, 10);
+    return Number.isFinite(offset) && offset >= 0 ? offset : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function encodeCursorOffset(offset: number): string {
+  return Buffer.from(String(offset), 'utf8').toString('base64');
+}
+
+// Caps a list response to `limit` items starting at `cursor`, returning an
+// envelope that tells the agent how much it is seeing and how to get the rest.
+// Only arrays are paginated; any other shape is passed through untouched.
+function capListResult(
+  result: unknown,
+  options: { limit?: number; cursor?: string }
+): { content: Array<{ type: 'text'; text: string }> } {
+  const limit = Math.min(options.limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
+  const offset = decodeCursorOffset(options.cursor);
+
+  if (!Array.isArray(result)) {
+    return {
+      content: [
+        { type: 'text' as const, text: JSON.stringify(result, null, 2) },
+      ],
+    };
+  }
+
+  const total = result.length;
+  const page = result.slice(offset, offset + limit);
+  const nextOffset = offset + page.length;
+  const hasMore = nextOffset < total;
+
+  const envelope = {
+    items: page,
+    pagination: {
+      total,
+      returned: page.length,
+      offset,
+      truncated: hasMore,
+      nextCursor: hasMore ? encodeCursorOffset(nextOffset) : null,
+      note: hasMore
+        ? `Showing ${page.length} of ${total}. Pass cursor=nextCursor to fetch more, or narrow the query with filters.`
+        : undefined,
+    },
+  };
+
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(envelope, null, 2) },
+    ],
+  };
+}
+
 // Helper function to make authenticated API requests to Runpod REST API
 function createRunpodRequest(
   apiKey: string,
@@ -408,6 +510,7 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
   server.tool(
     'list-pods',
     {
+      ...listPaginationParams,
       computeType: z
         .enum(['GPU', 'CPU'])
         .optional()
@@ -460,14 +563,10 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
         : '';
       const result = await runpodRequest(`/pods${queryString}`);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return capListResult(result, {
+        limit: params.limit,
+        cursor: params.cursor,
+      });
     }
   );
 
@@ -668,6 +767,7 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
   server.tool(
     'list-endpoints',
     {
+      ...listPaginationParams,
       includeTemplate: z
         .boolean()
         .optional()
@@ -693,14 +793,10 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
         : '';
       const result = await runpodRequest(`/endpoints${queryString}`);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return capListResult(result, {
+        limit: params.limit,
+        cursor: params.cursor,
+      });
     }
   );
 
@@ -1199,6 +1295,7 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
     'list-templates',
     'List available templates. By default returns only the user\'s own templates. Use includeRunpodTemplates to also include official Runpod templates. The recommended default template for new pods is "Runpod Pytorch 2.8.0" (ID: runpod-torch-v280) — it has the latest CUDA and PyTorch versions.',
     {
+      ...listPaginationParams,
       includeRunpodTemplates: z
         .boolean()
         .optional()
@@ -1227,14 +1324,10 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
         `/templates${query ? `?${query}` : ''}`
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return capListResult(result, {
+        limit: params.limit,
+        cursor: params.cursor,
+      });
     }
   );
 
@@ -1368,17 +1461,13 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
   // ============== NETWORK VOLUME MANAGEMENT TOOLS ==============
 
   // List Network Volumes
-  server.tool('list-network-volumes', {}, async () => {
+  server.tool('list-network-volumes', listPaginationParams, async (params) => {
     const result = await runpodRequest('/networkvolumes');
 
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(result, null, 2),
-        },
-      ],
-    };
+    return capListResult(result, {
+      limit: params.limit,
+      cursor: params.cursor,
+    });
   });
 
   // Get Network Volume Details
@@ -1487,18 +1576,18 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
   // ============== CONTAINER REGISTRY AUTH TOOLS ==============
 
   // List Container Registry Auths
-  server.tool('list-container-registry-auths', {}, async () => {
-    const result = await runpodRequest('/containerregistryauth');
+  server.tool(
+    'list-container-registry-auths',
+    listPaginationParams,
+    async (params) => {
+      const result = await runpodRequest('/containerregistryauth');
 
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(result, null, 2),
-        },
-      ],
-    };
-  });
+      return capListResult(result, {
+        limit: params.limit,
+        cursor: params.cursor,
+      });
+    }
+  );
 
   // Get Container Registry Auth Details
   server.tool(

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+  capListResult,
+  decodeCursorOffset,
+  encodeCursorOffset,
+} from '../src/pagination.js';
+
+// Parses the single text payload a list tool returns back into an object.
+function parse(result: { content: Array<{ type: 'text'; text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('cursor encode/decode', () => {
+  it('round-trips an offset', () => {
+    assert.equal(decodeCursorOffset(encodeCursorOffset(40)), 40);
+  });
+
+  it('treats an undefined cursor as offset 0', () => {
+    assert.equal(decodeCursorOffset(undefined), 0);
+  });
+
+  it('treats a garbage cursor as offset 0 instead of throwing', () => {
+    assert.equal(decodeCursorOffset('not-a-real-cursor'), 0);
+    assert.equal(decodeCursorOffset(''), 0);
+  });
+
+  it('treats a negative offset as 0', () => {
+    assert.equal(decodeCursorOffset(encodeCursorOffset(-5)), 0);
+  });
+});
+
+describe('capListResult', () => {
+  const makeItems = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({ id: `item-${i}` }));
+
+  it('returns all items and no cursor when under the limit', () => {
+    const out = parse(capListResult(makeItems(5), {}));
+    assert.equal(out.items.length, 5);
+    assert.equal(out.pagination.total, 5);
+    assert.equal(out.pagination.returned, 5);
+    assert.equal(out.pagination.truncated, false);
+    assert.equal(out.pagination.nextCursor, null);
+  });
+
+  it('caps to the default limit and reports truncation', () => {
+    const out = parse(capListResult(makeItems(50), {}));
+    assert.equal(out.items.length, DEFAULT_LIST_LIMIT);
+    assert.equal(out.pagination.total, 50);
+    assert.equal(out.pagination.truncated, true);
+    assert.ok(out.pagination.nextCursor);
+  });
+
+  it('honors an explicit limit', () => {
+    const out = parse(capListResult(makeItems(50), { limit: 5 }));
+    assert.equal(out.items.length, 5);
+    assert.equal(out.pagination.truncated, true);
+  });
+
+  it('clamps a limit above the ceiling to MAX_LIST_LIMIT', () => {
+    const out = parse(capListResult(makeItems(500), { limit: 9999 }));
+    assert.equal(out.items.length, MAX_LIST_LIMIT);
+  });
+
+  it('paginates through the full list with the returned cursor', () => {
+    const items = makeItems(45);
+    const first = parse(capListResult(items, { limit: 20 }));
+    assert.equal(first.items[0].id, 'item-0');
+    assert.equal(first.items.length, 20);
+
+    const second = parse(
+      capListResult(items, { limit: 20, cursor: first.pagination.nextCursor })
+    );
+    assert.equal(second.items[0].id, 'item-20');
+    assert.equal(second.items.length, 20);
+
+    const third = parse(
+      capListResult(items, { limit: 20, cursor: second.pagination.nextCursor })
+    );
+    assert.equal(third.items[0].id, 'item-40');
+    assert.equal(third.items.length, 5);
+    assert.equal(third.pagination.truncated, false);
+    assert.equal(third.pagination.nextCursor, null);
+  });
+
+  it('handles an empty list', () => {
+    const out = parse(capListResult([], {}));
+    assert.equal(out.items.length, 0);
+    assert.equal(out.pagination.total, 0);
+    assert.equal(out.pagination.truncated, false);
+  });
+
+  it('passes non-array results through untouched (no envelope)', () => {
+    const errorShape = { error: 'something went wrong' };
+    const out = parse(capListResult(errorShape, {}));
+    assert.deepEqual(out, errorShape);
+    assert.equal(out.pagination, undefined);
+  });
+
+  it('returns an empty page when the cursor is past the end', () => {
+    const out = parse(
+      capListResult(makeItems(10), { cursor: encodeCursorOffset(100) })
+    );
+    assert.equal(out.items.length, 0);
+    assert.equal(out.pagination.truncated, false);
+    assert.equal(out.pagination.nextCursor, null);
+  });
+});

--- a/tests/tools-registration.test.ts
+++ b/tests/tools-registration.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTools } from '../src/tools.js';
+
+// A minimal stand-in for McpServer that records every server.tool(...) call.
+// registerTools only calls `.tool()` at registration time (the tracking
+// helpers that touch `server.server` run per-request, not here), so this is
+// enough to introspect the registered surface without any network or SDK.
+function captureRegisteredTools(): {
+  names: string[];
+  schemas: Map<string, Record<string, unknown>>;
+} {
+  const names: string[] = [];
+  const schemas = new Map<string, Record<string, unknown>>();
+
+  const fakeServer = {
+    tool(name: string, ...args: unknown[]) {
+      names.push(name);
+      // The schema is the first plain-object argument after the name
+      // (a tool may pass a description string before it).
+      const schema = args.find(
+        (a) => a !== null && typeof a === 'object' && !Array.isArray(a)
+      );
+      if (schema) schemas.set(name, schema as Record<string, unknown>);
+    },
+  } as unknown as McpServer;
+
+  registerTools(fakeServer, { apiKey: 'test-key', transport: 'stdio' });
+  return { names, schemas };
+}
+
+const LIST_TOOLS = [
+  'list-pods',
+  'list-endpoints',
+  'list-templates',
+  'list-network-volumes',
+  'list-container-registry-auths',
+];
+
+// A high-frequency core that must always be present. Intentionally a subset,
+// not the full surface, so the test is not brittle to additive changes.
+const CORE_TOOLS = [
+  'create-pod',
+  'get-pod',
+  'stop-pod',
+  'list-pods',
+  'create-endpoint',
+  'run-endpoint',
+  'list-endpoints',
+  'create-template',
+  'list-templates',
+  'list-gpu-types',
+  ...LIST_TOOLS,
+];
+
+describe('tool registration', () => {
+  it('registers a non-trivial number of tools', () => {
+    const { names } = captureRegisteredTools();
+    assert.ok(
+      names.length >= 30,
+      `expected at least 30 tools, got ${names.length}`
+    );
+  });
+
+  it('registers every expected core tool', () => {
+    const { names } = captureRegisteredTools();
+    for (const tool of CORE_TOOLS) {
+      assert.ok(names.includes(tool), `missing tool: ${tool}`);
+    }
+  });
+
+  it('registers no duplicate tool names', () => {
+    const { names } = captureRegisteredTools();
+    const seen = new Set<string>();
+    const dupes = names.filter((n) => (seen.has(n) ? true : (seen.add(n), false)));
+    assert.deepEqual(dupes, [], `duplicate tool names: ${dupes.join(', ')}`);
+  });
+
+  it('exposes limit + cursor pagination params on every list-* tool', () => {
+    const { schemas } = captureRegisteredTools();
+    for (const tool of LIST_TOOLS) {
+      const schema = schemas.get(tool);
+      assert.ok(schema, `no schema captured for ${tool}`);
+      assert.ok('limit' in schema, `${tool} missing 'limit' param`);
+      assert.ok('cursor' in schema, `${tool} missing 'cursor' param`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Two things, both fixing structural gaps flagged in the Agents Emergency Triage PRD:

1. **Stop list tools from blowing up the agent's context.** The MCP `list-*` tools serialized the full REST response, and the REST list endpoints have no server-side pagination, so a large account returns a payload many times an LLM's context window (`list-templates` observed at ~15x Claude Code's window), ending the session. This adds a **client-side cap**.
2. **Bootstrap a test suite** (the repo had none) so this logic — and future generated tools — are gated in CI.

## Changes

### Pagination / token caps
- New `src/pagination.ts` module: `capListResult` + shared `listPaginationParams` (optional `limit`/`cursor`).
- Applied to all five list tools: `list-pods`, `list-endpoints`, `list-templates`, `list-network-volumes`, `list-container-registry-auths`.
- Responses return at most `limit` items (default 20, max 100) in a `{ items, pagination }` envelope reporting `total`, `returned`, `offset`, `truncated`, and a `nextCursor`.
- Optional params, so existing callers that pass nothing keep working (default page).

### Test suite (new)
- Node's built-in test runner via `tsx` — no new dependency. Added `pnpm test`.
- `tests/pagination.test.ts`: cursor round-trip + garbage/negative handling, default/explicit limit, clamp to ceiling, multi-page walk, empty list, non-array passthrough, cursor past end.
- `tests/tools-registration.test.ts`: drives the real `registerTools`; asserts the core tool set registers, no duplicate tool names, and every `list-*` tool exposes `limit`/`cursor`.
- `scripts/smoke-list.ts`: live end-to-end check (boots stdio server, real MCP client, calls each list tool) for manual verification.

## Forward-compatibility
REST will add cursor-based pagination (needs upstream GraphQL pagination per endpoint). The `limit`/`cursor` signature here matches it, so the tool interface won't change when server-side pagination lands; the MCP will forward the params and surface a real cursor. The client-side cap stays as a backstop.

## Test plan
- [x] `pnpm test` — 16 tests pass
- [x] `tsc --noEmit` clean
- [x] `tsup` build succeeds
- [x] `eslint` clean
- [x] **Live end-to-end against a real account** via `scripts/smoke-list.ts`: `list-templates` returned 26 total, capped to 20, `truncated: true`, `nextCursor: "MjA="`; paging with that cursor returned the remaining 6 (`offset: 20`, `truncated: false`). The other four list tools were under the cap and returned fully (no over-truncation).

🤖 Generated with [Claude Code](https://claude.ai/code)