### PR TITLE
[Phase A · PR1] Adapter core: unwrapList, resolveVersion, probe, resolveBackend (v1)

### DIFF
--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -134,39 +134,61 @@ export function resolveVersion(opts: {
 // response) pins true/false, but a transient failure (thrown error or 5xx) is
 // NOT cached — it returns false for this call and re-probes next time, so a
 // one-time startup network blip doesn't pin the process to v1 forever.
-type FetchLike = (
+// Exported so the stdio entrypoint can type its node-fetch adapter against the
+// exact shape the prober needs (just `{ status }`), instead of casting.
+export type FetchLike = (
   url: string,
   init?: { method?: string; headers?: Record<string, string> }
 ) => Promise<{ status: number }>;
 
-export function createV2Prober(deps: {
+export interface ProbeDeps {
   fetch: FetchLike;
   baseUrl: string;
   apiKey: string;
-}): () => Promise<boolean> {
+}
+
+// Classify a probe response status into a definitive verdict, or `undefined` for
+// a transient failure (5xx) that must NOT be cached.
+function classifyProbeStatus(status: number): boolean | undefined {
+  if (status >= 500) return undefined;
+  return status >= 200 && status < 300;
+}
+
+// One probe attempt. Returns a definitive verdict, or `undefined` when the
+// attempt was transient (network throw / 5xx) and should be retried.
+async function runV2Probe(deps: ProbeDeps): Promise<boolean | undefined> {
+  try {
+    const res = await deps.fetch(`${deps.baseUrl}/catalog/gpus`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${deps.apiKey}` },
+    });
+    return classifyProbeStatus(res.status);
+  } catch {
+    return undefined;
+  }
+}
+
+// Memoizing v2 prober: probes once, caches only a *definitive* verdict, and
+// coalesces concurrent first-calls onto a single in-flight probe. A transient
+// attempt resolves to false for this call but leaves the cache unset, so the
+// next call re-probes (a one-time startup blip can't pin the process to v1).
+export function createV2Prober(deps: ProbeDeps): () => Promise<boolean> {
   let cached: boolean | undefined;
   let inFlight: Promise<boolean> | undefined;
 
-  return function probeV2(): Promise<boolean> {
-    if (cached !== undefined) return Promise.resolve(cached);
-    // Coalesce concurrent first-calls onto one in-flight probe.
-    if (inFlight) return inFlight;
+  const probeOnce = async (): Promise<boolean> => {
+    const verdict = await runV2Probe(deps);
+    if (verdict !== undefined) cached = verdict;
+    return verdict ?? false;
+  };
 
-    inFlight = (async () => {
-      try {
-        const res = await deps.fetch(`${deps.baseUrl}/catalog/gpus`, {
-          method: 'GET',
-          headers: { Authorization: `Bearer ${deps.apiKey}` },
-        });
-        if (res.status >= 500) return false; // transient — do not cache
-        cached = res.status >= 200 && res.status < 300;
-        return cached;
-      } catch {
-        return false; // transient — do not cache
-      } finally {
+  return () => {
+    if (cached !== undefined) return Promise.resolve(cached);
+    if (!inFlight) {
+      inFlight = probeOnce().finally(() => {
         inFlight = undefined;
-      }
-    })();
+      });
+    }
     return inFlight;
   };
 }

--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -85,11 +85,17 @@ export function unwrapList(
 }
 
 // ---- A1: resolve which version a given resource call should use ----
-// Pure: env, transport, and the (already-resolved) probe verdict are injected.
+// Pure: env, transport, and the already-resolved v2 probe verdict are injected.
 // Precedence: v1-only resources → v1; else RUNPOD_REST_VERSION_<RESOURCE> →
 // RUNPOD_REST_VERSION → default 'v1'. `auto` probes only on stdio (one process =
 // one key); on hosted HTTP `auto` is treated as v1 (a warm instance serves many
 // keys, so a cached probe verdict would leak across users).
+//
+// `v2Available` is a *resolved boolean*, NOT a thunk or a promise: the caller
+// awaits createV2Prober() once at startup (stdio only) and passes the boolean
+// in. This is deliberate — a `() => Promise<boolean>` would be truthy even when
+// the probe failed, silently forcing v2. Keeping it a plain boolean removes that
+// footgun. When omitted under `auto`, we conservatively resolve to v1.
 export interface VersionCtx {
   transport: 'stdio' | 'http';
 }
@@ -98,9 +104,9 @@ export function resolveVersion(opts: {
   resource: Resource;
   env: Env;
   ctx: VersionCtx;
-  probe?: () => boolean;
+  v2Available?: boolean;
 }): RestVersion {
-  const { resource, env, ctx, probe } = opts;
+  const { resource, env, ctx, v2Available } = opts;
   if (V1_ONLY.has(resource)) return 'v1';
 
   const perResource = env[`RUNPOD_REST_VERSION_${RESOURCE_ENV_KEY[resource]}`];
@@ -113,14 +119,21 @@ export function resolveVersion(opts: {
   if (setting === 'v2') return 'v2';
   if (setting === 'auto') {
     if (ctx.transport === 'http') return 'v1';
-    return probe && probe() ? 'v2' : 'v1';
+    return v2Available === true ? 'v2' : 'v1';
   }
   return 'v1';
 }
 
 // ---- A1b: the real `auto` probe (decision logic, injected fetch) ----
-// Returns a thunk that resolves the v2 verdict once and memoizes it for the
-// process. stdio-only: never wire this into the HTTP path (see resolveVersion).
+// Returns an async resolver that probes once and memoizes the verdict for the
+// process. The startup wiring (stdio only) awaits this once, then passes the
+// resulting boolean to resolveVersion as `v2Available`. Never wire into the HTTP
+// path (see resolveVersion).
+//
+// Only *definitive* verdicts are cached: a reachable endpoint (any non-5xx
+// response) pins true/false, but a transient failure (thrown error or 5xx) is
+// NOT cached — it returns false for this call and re-probes next time, so a
+// one-time startup network blip doesn't pin the process to v1 forever.
 type FetchLike = (
   url: string,
   init?: { method?: string; headers?: Record<string, string> }
@@ -132,18 +145,29 @@ export function createV2Prober(deps: {
   apiKey: string;
 }): () => Promise<boolean> {
   let cached: boolean | undefined;
-  return async function probeV2(): Promise<boolean> {
-    if (cached !== undefined) return cached;
-    try {
-      const res = await deps.fetch(`${deps.baseUrl}/catalog/gpus`, {
-        method: 'GET',
-        headers: { Authorization: `Bearer ${deps.apiKey}` },
-      });
-      cached = res.status >= 200 && res.status < 300;
-    } catch {
-      cached = false;
-    }
-    return cached;
+  let inFlight: Promise<boolean> | undefined;
+
+  return function probeV2(): Promise<boolean> {
+    if (cached !== undefined) return Promise.resolve(cached);
+    // Coalesce concurrent first-calls onto one in-flight probe.
+    if (inFlight) return inFlight;
+
+    inFlight = (async () => {
+      try {
+        const res = await deps.fetch(`${deps.baseUrl}/catalog/gpus`, {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${deps.apiKey}` },
+        });
+        if (res.status >= 500) return false; // transient — do not cache
+        cached = res.status >= 200 && res.status < 300;
+        return cached;
+      } catch {
+        return false; // transient — do not cache
+      } finally {
+        inFlight = undefined;
+      }
+    })();
+    return inFlight;
   };
 }
 
@@ -193,7 +217,7 @@ export function resolveBackend(opts: {
   resource: Resource;
   env: Env;
   ctx: VersionCtx;
-  probe?: () => boolean;
+  v2Available?: boolean;
 }): Backend {
   const { resource, env } = opts;
   const version = resolveVersion(opts);

--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -1,0 +1,249 @@
+// ============== BACKEND ADAPTER (v1/v2 routing core) ==============
+// Pure routing layer that lets tools stay version-agnostic. A tool asks for a
+// resource backend; the adapter decides v1 vs v2, resolves the base URL + path,
+// normalizes the list response shape (`unwrapList`), and maps request bodies.
+//
+// This module is intentionally pure and side-effect free: env, transport, and
+// the v2 probe are all passed in, so every function is unit-testable offline
+// with no network and no MCP SDK. The HTTP client (src/_shared/http.ts) and the
+// per-resource tool handlers (src/tools/<resource>.ts) consume this.
+
+// One canonical resource union used by unwrapList, resolveVersion, and
+// resolveBackend alike — so the steps don't each invent a spelling. The v2
+// list-envelope key happens to equal the resource name.
+export type Resource =
+  | 'pods'
+  | 'templates'
+  | 'networkVolumes'
+  | 'registries'
+  | 'gpus'
+  | 'cpus'
+  | 'dataCenters'
+  | 'endpoints'
+  | 'jobs';
+
+export type RestVersion = 'v1' | 'v2';
+
+// Resources that have no v2 REST home and stay on v1 regardless of any flag.
+// - jobs: serverless runtime, lives on api.runpod.ai/v2 (a different service)
+// - endpoints: endpoint CRUD, REST base — v2 has no /v2/endpoints yet
+const V1_ONLY: ReadonlySet<Resource> = new Set<Resource>(['jobs', 'endpoints']);
+
+// The key each v2 list response is wrapped in: `{ pods: [...] }`, etc.
+const V2_UNWRAP_KEY: Record<Resource, string> = {
+  pods: 'pods',
+  templates: 'templates',
+  networkVolumes: 'networkVolumes',
+  registries: 'registries',
+  gpus: 'gpus',
+  cpus: 'cpus',
+  dataCenters: 'dataCenters',
+  endpoints: 'endpoints',
+  jobs: 'jobs',
+};
+
+// Env-var suffix for the per-resource version override (RUNPOD_REST_VERSION_<KEY>).
+const RESOURCE_ENV_KEY: Record<Resource, string> = {
+  pods: 'PODS',
+  templates: 'TEMPLATES',
+  networkVolumes: 'NETWORK_VOLUMES',
+  registries: 'REGISTRIES',
+  gpus: 'GPUS',
+  cpus: 'CPUS',
+  dataCenters: 'DATA_CENTERS',
+  endpoints: 'ENDPOINTS',
+  jobs: 'JOBS',
+};
+
+// ---- Base URLs (resolved from env, with the same defaults tools.ts uses) ----
+
+export type Env = Record<string, string | undefined>;
+
+export function restV1Base(env: Env): string {
+  return env.RUNPOD_REST_API_URL ?? 'https://rest.runpod.io/v1';
+}
+export function restV2Base(env: Env): string {
+  return env.RUNPOD_REST_V2_API_URL ?? 'https://v2-rest.runpod.io/v2';
+}
+export function serverlessBase(env: Env): string {
+  return env.RUNPOD_SERVERLESS_API_URL ?? 'https://api.runpod.ai/v2';
+}
+
+// ---- A0: unwrap a list response into a plain array ----
+// v1 returns a bare array; v2 wraps it in a per-resource envelope. Either way
+// we hand `capListResult` a plain array. Anything unexpected → [] (never throws
+// in an agent's face, and never passes a non-array through to the cap).
+export function unwrapList(
+  resource: Resource,
+  version: RestVersion,
+  raw: unknown
+): unknown[] {
+  if (version === 'v1') return Array.isArray(raw) ? raw : [];
+  if (raw === null || typeof raw !== 'object') return [];
+  const arr = (raw as Record<string, unknown>)[V2_UNWRAP_KEY[resource]];
+  return Array.isArray(arr) ? arr : [];
+}
+
+// ---- A1: resolve which version a given resource call should use ----
+// Pure: env, transport, and the (already-resolved) probe verdict are injected.
+// Precedence: v1-only resources → v1; else RUNPOD_REST_VERSION_<RESOURCE> →
+// RUNPOD_REST_VERSION → default 'v1'. `auto` probes only on stdio (one process =
+// one key); on hosted HTTP `auto` is treated as v1 (a warm instance serves many
+// keys, so a cached probe verdict would leak across users).
+export interface VersionCtx {
+  transport: 'stdio' | 'http';
+}
+
+export function resolveVersion(opts: {
+  resource: Resource;
+  env: Env;
+  ctx: VersionCtx;
+  probe?: () => boolean;
+}): RestVersion {
+  const { resource, env, ctx, probe } = opts;
+  if (V1_ONLY.has(resource)) return 'v1';
+
+  const perResource = env[`RUNPOD_REST_VERSION_${RESOURCE_ENV_KEY[resource]}`];
+  const setting = (
+    perResource ??
+    env.RUNPOD_REST_VERSION ??
+    'v1'
+  ).toLowerCase();
+
+  if (setting === 'v2') return 'v2';
+  if (setting === 'auto') {
+    if (ctx.transport === 'http') return 'v1';
+    return probe && probe() ? 'v2' : 'v1';
+  }
+  return 'v1';
+}
+
+// ---- A1b: the real `auto` probe (decision logic, injected fetch) ----
+// Returns a thunk that resolves the v2 verdict once and memoizes it for the
+// process. stdio-only: never wire this into the HTTP path (see resolveVersion).
+type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> }
+) => Promise<{ status: number }>;
+
+export function createV2Prober(deps: {
+  fetch: FetchLike;
+  baseUrl: string;
+  apiKey: string;
+}): () => Promise<boolean> {
+  let cached: boolean | undefined;
+  return async function probeV2(): Promise<boolean> {
+    if (cached !== undefined) return cached;
+    try {
+      const res = await deps.fetch(`${deps.baseUrl}/catalog/gpus`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${deps.apiKey}` },
+      });
+      cached = res.status >= 200 && res.status < 300;
+    } catch {
+      cached = false;
+    }
+    return cached;
+  };
+}
+
+// ---- A2: resolve the backend descriptor for a resource ----
+// `kind` distinguishes a normal REST resource from the GraphQL-backed catalog
+// (v1) and the serverless-runtime jobs base. mapCreate/mapUpdate default to
+// identity under v1; Phase B fills the v2 half (paths + body mappers + unwrap).
+export type BackendKind = 'rest' | 'graphql';
+
+export interface Backend {
+  kind: BackendKind;
+  version: RestVersion;
+  base: string;
+  list?: string;
+  get?: (id: string) => string;
+  unwrap: (raw: unknown) => unknown[];
+  mapCreate: (body: unknown) => unknown;
+  mapUpdate: (body: unknown) => unknown;
+}
+
+const identity = (body: unknown): unknown => body;
+
+// v1 REST paths, exactly as tools.ts uses them today.
+const V1_REST_PATHS: Partial<
+  Record<Resource, { list: string; get: (id: string) => string }>
+> = {
+  pods: { list: '/pods', get: (id) => `/pods/${id}` },
+  templates: { list: '/templates', get: (id) => `/templates/${id}` },
+  networkVolumes: {
+    list: '/networkvolumes',
+    get: (id) => `/networkvolumes/${id}`,
+  },
+  registries: {
+    list: '/containerregistryauth',
+    get: (id) => `/containerregistryauth/${id}`,
+  },
+  endpoints: { list: '/endpoints', get: (id) => `/endpoints/${id}` },
+};
+
+const CATALOG: ReadonlySet<Resource> = new Set<Resource>([
+  'gpus',
+  'cpus',
+  'dataCenters',
+]);
+
+export function resolveBackend(opts: {
+  resource: Resource;
+  env: Env;
+  ctx: VersionCtx;
+  probe?: () => boolean;
+}): Backend {
+  const { resource, env } = opts;
+  const version = resolveVersion(opts);
+  const unwrap = (raw: unknown): unknown[] =>
+    unwrapList(resource, version, raw);
+
+  if (version === 'v2') {
+    // Filled in Phase B (B2/B1/B3/B5). Throwing here keeps the v1-only Phase A
+    // honest: nothing routes to v2 until the mappers + paths exist.
+    throw new Error(
+      `v2 backend for "${resource}" not implemented until Phase B`
+    );
+  }
+
+  // ---- v1 ----
+  if (resource === 'jobs') {
+    return {
+      kind: 'rest',
+      version,
+      base: serverlessBase(env),
+      unwrap,
+      mapCreate: identity,
+      mapUpdate: identity,
+    };
+  }
+  if (CATALOG.has(resource)) {
+    // v1 catalog is GraphQL via a separate helper (kept out of the unified REST
+    // client through Phase A); folds into REST at Step B5.
+    return {
+      kind: 'graphql',
+      version,
+      base: env.RUNPOD_PUBLIC_GRAPHQL_URL ?? 'https://api.runpod.io/graphql',
+      unwrap,
+      mapCreate: identity,
+      mapUpdate: identity,
+    };
+  }
+
+  const paths = V1_REST_PATHS[resource];
+  if (!paths) {
+    throw new Error(`no v1 REST paths for resource "${resource}"`);
+  }
+  return {
+    kind: 'rest',
+    version,
+    base: restV1Base(env),
+    list: paths.list,
+    get: paths.get,
+    unwrap,
+    mapCreate: identity,
+    mapUpdate: identity,
+  };
+}

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -1,0 +1,260 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  unwrapList,
+  resolveVersion,
+  createV2Prober,
+  resolveBackend,
+  type Resource,
+} from '../src/_shared/backend.js';
+
+// ============== A0: unwrapList ==============
+describe('unwrapList', () => {
+  it('v1: returns a bare array unchanged', () => {
+    const arr = [{ id: 'a' }, { id: 'b' }];
+    assert.deepEqual(unwrapList('pods', 'v1', arr), arr);
+  });
+
+  it('v1: non-array → [] (never passes a non-array to the cap)', () => {
+    assert.deepEqual(unwrapList('pods', 'v1', { pods: [] }), []);
+    assert.deepEqual(unwrapList('pods', 'v1', null), []);
+  });
+
+  it('v2: unwraps the per-resource envelope key', () => {
+    const cases: Array<[Resource, string]> = [
+      ['pods', 'pods'],
+      ['templates', 'templates'],
+      ['networkVolumes', 'networkVolumes'],
+      ['registries', 'registries'],
+      ['gpus', 'gpus'],
+      ['cpus', 'cpus'],
+      ['dataCenters', 'dataCenters'],
+    ];
+    for (const [resource, key] of cases) {
+      const inner = [{ id: '1' }];
+      assert.deepEqual(
+        unwrapList(resource, 'v2', { [key]: inner }),
+        inner,
+        `resource ${resource} should unwrap key ${key}`
+      );
+    }
+  });
+
+  it('v2: empty envelope → empty array (not passthrough)', () => {
+    assert.deepEqual(unwrapList('pods', 'v2', { pods: [] }), []);
+  });
+
+  it('v2: missing key → []', () => {
+    assert.deepEqual(unwrapList('pods', 'v2', { somethingElse: [] }), []);
+  });
+
+  it('v2: non-object → []', () => {
+    assert.deepEqual(unwrapList('pods', 'v2', null), []);
+    assert.deepEqual(unwrapList('pods', 'v2', 'nope'), []);
+    assert.deepEqual(unwrapList('pods', 'v2', [1, 2]), []);
+  });
+});
+
+// ============== A1: resolveVersion ==============
+describe('resolveVersion', () => {
+  const stdio = { transport: 'stdio' as const };
+  const http = { transport: 'http' as const };
+
+  it('jobs and endpoints are always v1, regardless of env', () => {
+    const env = { RUNPOD_REST_VERSION: 'v2' };
+    assert.equal(resolveVersion({ resource: 'jobs', env, ctx: stdio }), 'v1');
+    assert.equal(
+      resolveVersion({ resource: 'endpoints', env, ctx: stdio }),
+      'v1'
+    );
+  });
+
+  it('control-plane follows RUNPOD_REST_VERSION', () => {
+    assert.equal(
+      resolveVersion({
+        resource: 'pods',
+        env: { RUNPOD_REST_VERSION: 'v2' },
+        ctx: stdio,
+      }),
+      'v2'
+    );
+    assert.equal(
+      resolveVersion({
+        resource: 'pods',
+        env: { RUNPOD_REST_VERSION: 'v1' },
+        ctx: stdio,
+      }),
+      'v1'
+    );
+  });
+
+  it('unset defaults to v1', () => {
+    assert.equal(
+      resolveVersion({ resource: 'pods', env: {}, ctx: stdio }),
+      'v1'
+    );
+  });
+
+  it('per-resource override beats the global', () => {
+    const env = { RUNPOD_REST_VERSION: 'v1', RUNPOD_REST_VERSION_PODS: 'v2' };
+    assert.equal(resolveVersion({ resource: 'pods', env, ctx: stdio }), 'v2');
+    // a resource without an override inherits the global
+    assert.equal(
+      resolveVersion({ resource: 'templates', env, ctx: stdio }),
+      'v1'
+    );
+  });
+
+  it('auto + http → v1 (no per-request probe on hosted)', () => {
+    const env = { RUNPOD_REST_VERSION: 'auto' };
+    assert.equal(
+      resolveVersion({ resource: 'pods', env, ctx: http, probe: () => true }),
+      'v1'
+    );
+  });
+
+  it('auto + stdio → probe verdict', () => {
+    const env = { RUNPOD_REST_VERSION: 'auto' };
+    assert.equal(
+      resolveVersion({ resource: 'pods', env, ctx: stdio, probe: () => true }),
+      'v2'
+    );
+    assert.equal(
+      resolveVersion({ resource: 'pods', env, ctx: stdio, probe: () => false }),
+      'v1'
+    );
+  });
+});
+
+// ============== A1b: createV2Prober (injected fetch, no network) ==============
+describe('createV2Prober', () => {
+  const mkFetch = (status: number, calls?: { n: number }) => async () => {
+    if (calls) calls.n++;
+    return { status };
+  };
+
+  it('2xx → true', async () => {
+    const probe = createV2Prober({
+      fetch: mkFetch(200),
+      baseUrl: 'x',
+      apiKey: 'k',
+    });
+    assert.equal(await probe(), true);
+  });
+
+  it('401 → false', async () => {
+    const probe = createV2Prober({
+      fetch: mkFetch(401),
+      baseUrl: 'x',
+      apiKey: 'k',
+    });
+    assert.equal(await probe(), false);
+  });
+
+  it('fetch throws → false', async () => {
+    const probe = createV2Prober({
+      fetch: async () => {
+        throw new Error('network down');
+      },
+      baseUrl: 'x',
+      apiKey: 'k',
+    });
+    assert.equal(await probe(), false);
+  });
+
+  it('memoizes: fetch called once across multiple calls', async () => {
+    const calls = { n: 0 };
+    const probe = createV2Prober({
+      fetch: mkFetch(200, calls),
+      baseUrl: 'x',
+      apiKey: 'k',
+    });
+    await probe();
+    await probe();
+    await probe();
+    assert.equal(calls.n, 1);
+  });
+});
+
+// ============== A2: resolveBackend (v1 descriptors) ==============
+describe('resolveBackend (v1)', () => {
+  const stdio = { transport: 'stdio' as const };
+  const env = {}; // all defaults
+
+  it('pods → REST v1 base + exact today paths + identity mappers', () => {
+    const b = resolveBackend({ resource: 'pods', env, ctx: stdio });
+    assert.equal(b.kind, 'rest');
+    assert.equal(b.version, 'v1');
+    assert.equal(b.base, 'https://rest.runpod.io/v1');
+    assert.equal(b.list, '/pods');
+    assert.equal(b.get!('pod_x'), '/pods/pod_x');
+  });
+
+  it('exact v1 list paths per resource', () => {
+    const expect: Array<[Resource, string]> = [
+      ['pods', '/pods'],
+      ['templates', '/templates'],
+      ['networkVolumes', '/networkvolumes'],
+      ['registries', '/containerregistryauth'],
+      ['endpoints', '/endpoints'],
+    ];
+    for (const [resource, list] of expect) {
+      const b = resolveBackend({ resource, env, ctx: stdio });
+      assert.equal(b.list, list, `${resource} list path`);
+    }
+  });
+
+  it('identity mappers under v1', () => {
+    const b = resolveBackend({ resource: 'pods', env, ctx: stdio });
+    const body = { imageName: 'img', gpuCount: 2 };
+    assert.deepEqual(b.mapCreate(body), body);
+    assert.deepEqual(b.mapUpdate(body), body);
+  });
+
+  it('unwrap is wired to v1 passthrough', () => {
+    const b = resolveBackend({ resource: 'pods', env, ctx: stdio });
+    const arr = [{ id: '1' }];
+    assert.deepEqual(b.unwrap(arr), arr);
+  });
+
+  it('jobs → serverless base', () => {
+    const b = resolveBackend({ resource: 'jobs', env, ctx: stdio });
+    assert.equal(b.base, 'https://api.runpod.ai/v2');
+    assert.equal(b.kind, 'rest');
+  });
+
+  it('catalog (gpus/cpus/dataCenters) → graphql kind under v1', () => {
+    for (const resource of ['gpus', 'cpus', 'dataCenters'] as Resource[]) {
+      const b = resolveBackend({ resource, env, ctx: stdio });
+      assert.equal(b.kind, 'graphql', `${resource} kind`);
+      assert.equal(b.base, 'https://api.runpod.io/graphql');
+    }
+  });
+
+  it('endpoints uses the REST v1 base, NOT the serverless base', () => {
+    const b = resolveBackend({ resource: 'endpoints', env, ctx: stdio });
+    assert.equal(b.base, 'https://rest.runpod.io/v1');
+  });
+
+  it('env overrides bases', () => {
+    const b = resolveBackend({
+      resource: 'pods',
+      env: { RUNPOD_REST_API_URL: 'http://localhost:9999/v1' },
+      ctx: stdio,
+    });
+    assert.equal(b.base, 'http://localhost:9999/v1');
+  });
+
+  it('v2 resolution throws until Phase B (keeps Phase A v1-only honest)', () => {
+    assert.throws(
+      () =>
+        resolveBackend({
+          resource: 'pods',
+          env: { RUNPOD_REST_VERSION: 'v2' },
+          ctx: stdio,
+        }),
+      /not implemented until Phase B/
+    );
+  });
+});

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -54,6 +54,11 @@ describe('unwrapList', () => {
     assert.deepEqual(unwrapList('pods', 'v2', 'nope'), []);
     assert.deepEqual(unwrapList('pods', 'v2', [1, 2]), []);
   });
+
+  it('undefined raw → [] for both versions', () => {
+    assert.deepEqual(unwrapList('pods', 'v1', undefined), []);
+    assert.deepEqual(unwrapList('pods', 'v2', undefined), []);
+  });
 });
 
 // ============== A1: resolveVersion ==============
@@ -96,7 +101,7 @@ describe('resolveVersion', () => {
     );
   });
 
-  it('per-resource override beats the global', () => {
+  it('per-resource override beats the global (v2 over v1)', () => {
     const env = { RUNPOD_REST_VERSION: 'v1', RUNPOD_REST_VERSION_PODS: 'v2' };
     assert.equal(resolveVersion({ resource: 'pods', env, ctx: stdio }), 'v2');
     // a resource without an override inherits the global
@@ -106,22 +111,73 @@ describe('resolveVersion', () => {
     );
   });
 
-  it('auto + http → v1 (no per-request probe on hosted)', () => {
-    const env = { RUNPOD_REST_VERSION: 'auto' };
+  it('per-resource override beats the global (v1 over v2)', () => {
+    const env = { RUNPOD_REST_VERSION: 'v2', RUNPOD_REST_VERSION_PODS: 'v1' };
+    assert.equal(resolveVersion({ resource: 'pods', env, ctx: stdio }), 'v1');
     assert.equal(
-      resolveVersion({ resource: 'pods', env, ctx: http, probe: () => true }),
+      resolveVersion({ resource: 'templates', env, ctx: stdio }),
+      'v2'
+    );
+  });
+
+  it('bogus RUNPOD_REST_VERSION falls back to v1', () => {
+    assert.equal(
+      resolveVersion({
+        resource: 'pods',
+        env: { RUNPOD_REST_VERSION: 'foo' },
+        ctx: stdio,
+      }),
       'v1'
     );
   });
 
-  it('auto + stdio → probe verdict', () => {
-    const env = { RUNPOD_REST_VERSION: 'auto' };
+  it('is case-insensitive (V2, AUTO)', () => {
     assert.equal(
-      resolveVersion({ resource: 'pods', env, ctx: stdio, probe: () => true }),
+      resolveVersion({
+        resource: 'pods',
+        env: { RUNPOD_REST_VERSION: 'V2' },
+        ctx: stdio,
+      }),
       'v2'
     );
     assert.equal(
-      resolveVersion({ resource: 'pods', env, ctx: stdio, probe: () => false }),
+      resolveVersion({
+        resource: 'pods',
+        env: { RUNPOD_REST_VERSION: 'AUTO' },
+        ctx: stdio,
+        v2Available: true,
+      }),
+      'v2'
+    );
+  });
+
+  it('auto + http → v1 (no per-request probe on hosted)', () => {
+    const env = { RUNPOD_REST_VERSION: 'auto' };
+    assert.equal(
+      resolveVersion({ resource: 'pods', env, ctx: http, v2Available: true }),
+      'v1'
+    );
+  });
+
+  it('auto + stdio → uses the resolved v2Available verdict', () => {
+    const env = { RUNPOD_REST_VERSION: 'auto' };
+    assert.equal(
+      resolveVersion({ resource: 'pods', env, ctx: stdio, v2Available: true }),
+      'v2'
+    );
+    assert.equal(
+      resolveVersion({ resource: 'pods', env, ctx: stdio, v2Available: false }),
+      'v1'
+    );
+  });
+
+  it('auto + stdio with no v2Available → v1 (conservative default)', () => {
+    assert.equal(
+      resolveVersion({
+        resource: 'pods',
+        env: { RUNPOD_REST_VERSION: 'auto' },
+        ctx: stdio,
+      }),
       'v1'
     );
   });
@@ -152,6 +208,29 @@ describe('createV2Prober', () => {
     assert.equal(await probe(), false);
   });
 
+  it('any 2xx → available (204 included); 3xx → not (pins the < 300 bound)', async () => {
+    for (const status of [200, 204, 299]) {
+      const probe = createV2Prober({
+        fetch: mkFetch(status),
+        baseUrl: 'x',
+        apiKey: 'k',
+      });
+      assert.equal(await probe(), true, `status ${status} should be available`);
+    }
+    for (const status of [300, 301, 404]) {
+      const probe = createV2Prober({
+        fetch: mkFetch(status),
+        baseUrl: 'x',
+        apiKey: 'k',
+      });
+      assert.equal(
+        await probe(),
+        false,
+        `status ${status} should not be available`
+      );
+    }
+  });
+
   it('fetch throws → false', async () => {
     const probe = createV2Prober({
       fetch: async () => {
@@ -163,7 +242,26 @@ describe('createV2Prober', () => {
     assert.equal(await probe(), false);
   });
 
-  it('memoizes: fetch called once across multiple calls', async () => {
+  it('sends GET to <base>/catalog/gpus with bearer auth', async () => {
+    let seen: {
+      url?: string;
+      init?: { method?: string; headers?: Record<string, string> };
+    } = {};
+    const probe = createV2Prober({
+      fetch: async (url, init) => {
+        seen = { url, init };
+        return { status: 200 };
+      },
+      baseUrl: 'https://v2-rest.runpod.dev/v2',
+      apiKey: 'rpa_xyz',
+    });
+    await probe();
+    assert.equal(seen.url, 'https://v2-rest.runpod.dev/v2/catalog/gpus');
+    assert.equal(seen.init?.method, 'GET');
+    assert.equal(seen.init?.headers?.Authorization, 'Bearer rpa_xyz');
+  });
+
+  it('memoizes a true verdict: fetch called once across calls', async () => {
     const calls = { n: 0 };
     const probe = createV2Prober({
       fetch: mkFetch(200, calls),
@@ -174,6 +272,53 @@ describe('createV2Prober', () => {
     await probe();
     await probe();
     assert.equal(calls.n, 1);
+  });
+
+  it('memoizes a false (401) verdict: does not re-probe', async () => {
+    const calls = { n: 0 };
+    const probe = createV2Prober({
+      fetch: mkFetch(401, calls),
+      baseUrl: 'x',
+      apiKey: 'k',
+    });
+    assert.equal(await probe(), false);
+    assert.equal(await probe(), false);
+    assert.equal(calls.n, 1, 'a definitive 401 verdict must be cached');
+  });
+
+  it('does NOT cache a transient failure (5xx) — re-probes and can recover', async () => {
+    let status = 503;
+    const calls = { n: 0 };
+    const probe = createV2Prober({
+      fetch: async () => {
+        calls.n++;
+        return { status };
+      },
+      baseUrl: 'x',
+      apiKey: 'k',
+    });
+    assert.equal(await probe(), false); // 5xx → false, not cached
+    status = 200;
+    assert.equal(await probe(), true, 'recovers once the endpoint is healthy');
+    assert.equal(calls.n, 2);
+  });
+
+  it('does NOT cache a thrown error — re-probes', async () => {
+    let throwIt = true;
+    const calls = { n: 0 };
+    const probe = createV2Prober({
+      fetch: async () => {
+        calls.n++;
+        if (throwIt) throw new Error('blip');
+        return { status: 200 };
+      },
+      baseUrl: 'x',
+      apiKey: 'k',
+    });
+    assert.equal(await probe(), false);
+    throwIt = false;
+    assert.equal(await probe(), true);
+    assert.equal(calls.n, 2);
   });
 });
 
@@ -205,11 +350,25 @@ describe('resolveBackend (v1)', () => {
     }
   });
 
-  it('identity mappers under v1', () => {
+  it('identity mappers under v1 (same reference, true passthrough)', () => {
     const b = resolveBackend({ resource: 'pods', env, ctx: stdio });
     const body = { imageName: 'img', gpuCount: 2 };
-    assert.deepEqual(b.mapCreate(body), body);
-    assert.deepEqual(b.mapUpdate(body), body);
+    assert.equal(b.mapCreate(body), body); // reference equality pins identity
+    assert.equal(b.mapUpdate(body), body);
+  });
+
+  it('get(id) interpolates id for every REST resource', () => {
+    const expect: Array<[Resource, string]> = [
+      ['pods', '/pods/X'],
+      ['templates', '/templates/X'],
+      ['networkVolumes', '/networkvolumes/X'],
+      ['registries', '/containerregistryauth/X'],
+      ['endpoints', '/endpoints/X'],
+    ];
+    for (const [resource, path] of expect) {
+      const b = resolveBackend({ resource, env, ctx: stdio });
+      assert.equal(b.get!('X'), path, `${resource} get path`);
+    }
   });
 
   it('unwrap is wired to v1 passthrough', () => {
@@ -218,17 +377,24 @@ describe('resolveBackend (v1)', () => {
     assert.deepEqual(b.unwrap(arr), arr);
   });
 
-  it('jobs → serverless base', () => {
+  it('jobs → serverless base, no list/get path, v1', () => {
     const b = resolveBackend({ resource: 'jobs', env, ctx: stdio });
     assert.equal(b.base, 'https://api.runpod.ai/v2');
     assert.equal(b.kind, 'rest');
+    assert.equal(b.version, 'v1');
+    assert.equal(b.list, undefined);
+    assert.equal(b.get, undefined);
+    assert.deepEqual(b.unwrap([{ id: 'j' }]), [{ id: 'j' }]); // v1 passthrough
   });
 
-  it('catalog (gpus/cpus/dataCenters) → graphql kind under v1', () => {
+  it('catalog (gpus/cpus/dataCenters) → graphql kind, no path, v1', () => {
     for (const resource of ['gpus', 'cpus', 'dataCenters'] as Resource[]) {
       const b = resolveBackend({ resource, env, ctx: stdio });
       assert.equal(b.kind, 'graphql', `${resource} kind`);
       assert.equal(b.base, 'https://api.runpod.io/graphql');
+      assert.equal(b.version, 'v1');
+      assert.equal(b.list, undefined, `${resource} should expose no list path`);
+      assert.equal(b.get, undefined, `${resource} should expose no get path`);
     }
   });
 
@@ -237,13 +403,73 @@ describe('resolveBackend (v1)', () => {
     assert.equal(b.base, 'https://rest.runpod.io/v1');
   });
 
-  it('env overrides bases', () => {
+  it('env overrides the REST base', () => {
     const b = resolveBackend({
       resource: 'pods',
       env: { RUNPOD_REST_API_URL: 'http://localhost:9999/v1' },
       ctx: stdio,
     });
     assert.equal(b.base, 'http://localhost:9999/v1');
+  });
+
+  it('env overrides the serverless base (jobs)', () => {
+    const b = resolveBackend({
+      resource: 'jobs',
+      env: { RUNPOD_SERVERLESS_API_URL: 'http://localhost:8/v2' },
+      ctx: stdio,
+    });
+    assert.equal(b.base, 'http://localhost:8/v2');
+  });
+
+  it('env overrides the graphql base (catalog)', () => {
+    const b = resolveBackend({
+      resource: 'gpus',
+      env: { RUNPOD_PUBLIC_GRAPHQL_URL: 'http://localhost:8/graphql' },
+      ctx: stdio,
+    });
+    assert.equal(b.base, 'http://localhost:8/graphql');
+  });
+
+  it('every resource resolves under v1 default env without throwing', () => {
+    const all: Resource[] = [
+      'pods',
+      'templates',
+      'networkVolumes',
+      'registries',
+      'gpus',
+      'cpus',
+      'dataCenters',
+      'endpoints',
+      'jobs',
+    ];
+    for (const resource of all) {
+      assert.doesNotThrow(
+        () => resolveBackend({ resource, env, ctx: stdio }),
+        `${resource} should resolve under v1`
+      );
+    }
+  });
+
+  it('forwards v2Available through to resolveVersion (auto+stdio)', () => {
+    // auto + no v2Available → v1 → resolves (does not throw)
+    assert.doesNotThrow(() =>
+      resolveBackend({
+        resource: 'pods',
+        env: { RUNPOD_REST_VERSION: 'auto' },
+        ctx: stdio,
+      })
+    );
+    // auto + v2Available:true → v2 → throws (Phase B not implemented)
+    assert.throws(
+      () =>
+        resolveBackend({
+          resource: 'pods',
+          env: { RUNPOD_REST_VERSION: 'auto' },
+          ctx: stdio,
+          v2Available: true,
+        }),
+      /not implemented until Phase B/
+    );
   });
 
   it('v2 resolution throws until Phase B (keeps Phase A v1-only honest)', () => {


### PR DESCRIPTION
**Stacked draft — do not merge.** Base = \`DO-NOT-MERGE-TILL-V2-LIVE/v2-rest-support\` (drafting workspace). Implements **Phase A / Steps A0–A2** of PLAN.md.

## What this is
The pure, additive routing core for the v1/v2 adapter. **No wiring into tools yet** — `tools.ts` is untouched, so v1 behavior is unchanged. This PR just adds `src/_shared/backend.ts` + tests.

## Contents
- **A0 `unwrapList(resource, version, raw)`** — v1 bare-array passthrough; v2 envelope unwrap (`{pods:[…]}` → array); non-array/missing-key → `[]`. Kills the envelope bug at the seam before v2 lands.
- **A1 `resolveVersion`** — per-resource `RUNPOD_REST_VERSION_<RES>` override → global `RUNPOD_REST_VERSION` → default `v1`. `auto` is stdio-only (http → v1, no cross-user probe leak). `jobs`/`endpoints` pinned v1.
- **A1b `createV2Prober`** — memoized probe, injected `fetch` (offline-testable).
- **A2 `resolveBackend`** — v1 REST descriptors with the **exact** current paths (`/pods`, `/networkvolumes`, `/containerregistryauth`, `/endpoints`), GraphQL `kind` for catalog, serverless base for `jobs`; v2 **throws** until Phase B (keeps Phase A honest).

## Tests / checks
- 25 new offline tests (no network, no SDK); **41 total pass**.
- `tsc --noEmit` clean · `eslint` clean · `tsup` build clean · new files prettier-clean.

## Notes
- `endpoints` correctly uses the **REST v1** base, not the serverless base.
- Pre-existing prettier warning in `tests/tools-registration.test.ts` is on the base branch, left untouched to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)