### PR TITLE
[Phase A · PR2] Unified HTTP client + pure tracking headers (A3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -311,8 +311,9 @@ GREEN, or their RED tests have nothing injectable to target. This is stated per-
   takes `fetch` as a param (today it's a module import, `tools.ts:3`); thread from `stdio.ts`/`http.ts`.
 - RED: `tests/http.test.ts`. Inject a fake `fetch`. Cases: builds `base+path`; sets
   `Authorization: Bearer <key>` + tracking headers; serializes body only for POST/PATCH;
-  `!ok → throws` with the configured error prefix (**provisional contract — C2 carves out
-  501 as the one non-throwing case; note that here so C2 amends rather than regresses**);
+  `!ok → throws HttpError` (carrying `.status` + `.body`) for **all** non-OK responses
+  including 501 — C2 *catches* the 501 throw and branches on `err.status`, so stream-job's
+  error counter still fires on a mid-poll 501;
   non-JSON / 204 / empty body → `{success:true,status}`; JSON → parsed; **`application/
   problem+json` (v2's error shape) parses as JSON** — match the `+json` *suffix*, NOT the
   literal substring `application/json` (`"application/problem+json".includes("application/json")`

--- a/PLAN.md
+++ b/PLAN.md
@@ -299,11 +299,14 @@ GREEN, or their RED tests have nothing injectable to target. This is stated per-
 
 **Step A3 — Unified HTTP client, injected `fetch`. (SCOPE: REST + Serverless only — NOT GraphQL.)**
 - **CONTRACT (pin this first — it threads through A3→A4→B4→C2):** the client is **low-level**,
-  signature `client(path, method?='GET', body?): Promise<unknown>` (mirrors today's
-  `runpodRequest`, `tools.ts:126-130`). On `!ok` it **throws** (stream-job's loop depends on
-  it, A4) — **except 501**, which it returns as `{unsupported:true,status:501}` (C2). It takes
-  a per-client `errorPrefix` option so `"Runpod API Error"` / `"Runpod Serverless API Error"`
-  / `"GraphQL Error:"` are preserved (decide here, not at A5).
+  signature `client(url, method?='GET', body?): Promise<unknown>` (takes a fully-resolved URL;
+  the adapter builds base+path). On `!ok` it **throws `HttpError`** carrying `.status` + `.body`
+  — for **all** non-OK responses including 501. This is a superset of today's "throw on any
+  !ok", so stream-job's consecutive-error loop keeps working AND create-pod (C2) can branch on
+  `err.status === 501` for a clean message. (This supersedes the earlier provisional idea of
+  *returning* `{unsupported}` on 501 — that would have defanged stream-job's error counter.)
+  Per-client `errorPrefix` keeps `"Runpod API Error"` / `"Runpod Serverless API Error"`
+  attributable. Content-type matches the `+json` suffix (v2 problem+json parsed, not swallowed).
 - PREREQ (GREEN): introduce the `fetch` seam — `createHttpClient({ apiKey, fetch, tracking, errorPrefix })`
   takes `fetch` as a param (today it's a module import, `tools.ts:3`); thread from `stdio.ts`/`http.ts`.
 - RED: `tests/http.test.ts`. Inject a fake `fetch`. Cases: builds `base+path`; sets
@@ -434,15 +437,15 @@ Each resource is one independent RED→GREEN cycle; order doesn't matter, do pod
   `list-cpu-types`, `get-gpu-type` register; the `>=30` + no-dupes checks still hold.
 - GREEN: add them via the adapter.
 
-**Step C2 — CPU-pod 501 → clean error (pin the contract — fake must match real).**
-- ⚠️ Today the client **throws** on any `!ok` (`tools.ts:150`), so 501 would throw, not
-  "return". Pick one and make the fake match: have `createHttpClient` **special-case 501
-  before the generic throw**, returning `{ unsupported: true, status: 501 }`; the
-  create-pod handler maps that to the clean message.
-- RED: `tests/handlers.test.ts` — injected client returns the `{unsupported:true,status:501}`
-  shape; assert the tool result is **non-error content** (`isError` falsy) containing
-  "CPU pods not yet supported on v2 REST", and does **not** throw.
-- GREEN: the 501 special-case in the client + the handler mapping.
+**Step C2 — CPU-pod 501 → clean error (reconciled with A3's HttpError design).**
+- The client throws `HttpError` on all `!ok` (A3), so the create-pod handler **catches
+  `HttpError` and branches on `err.status === 501`** → returns a clean message. (No
+  `{unsupported}` return — `HttpError.status` is exactly the field that enables this, and
+  keeping 501 a throw means stream-job still counts it.)
+- RED: `tests/handlers.test.ts` — injected client throws `new HttpError('...', 501, '...')`;
+  assert the create-pod tool result is **non-error content** (`isError` falsy) containing
+  "CPU pods not yet supported on v2 REST", and does **not** re-throw.
+- GREEN: the try/catch + `err.status === 501` branch in the create-pod handler.
 
 **Step C3 — Flip the default (per-resource, not one global switch).**
 - ⚠️ **Resolve the routing-vs-control contradiction.** Part 1.6 says routing is per-resource,

--- a/src/_shared/http.ts
+++ b/src/_shared/http.ts
@@ -11,14 +11,15 @@
 // `fetch` and `tracking` are injected so this is unit-testable offline with no
 // network and no MCP SDK.
 
-type FetchLike = (
-  url: string,
-  init: {
-    method: string;
-    headers: Record<string, string>;
-    body?: string;
-  }
-) => Promise<HttpResponseLike>;
+// The shape of a `fetch` request init this client builds. Named so the client's
+// internal `init` literal can't drift from what `FetchLike` actually accepts.
+interface RequestInitLike {
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+type FetchLike = (url: string, init: RequestInitLike) => Promise<HttpResponseLike>;
 
 interface HttpResponseLike {
   ok: boolean;
@@ -54,6 +55,24 @@ function isJsonContentType(contentType: string | null): boolean {
   return ct.includes('application/json') || ct.includes('+json');
 }
 
+// Only POST/PATCH carry a JSON body; GET/DELETE never do (matches the legacy
+// runpodRequest/serverlessRequest helpers this client replaced).
+function methodSendsBody(method: string): boolean {
+  return method === 'POST' || method === 'PATCH';
+}
+
+// The auth + content-type + caller-tracking headers sent on every request.
+function buildRequestHeaders(
+  apiKey: string,
+  tracking: () => Record<string, string>
+): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+    ...tracking(),
+  };
+}
+
 export interface HttpClient {
   (
     url: string,
@@ -75,36 +94,28 @@ export function createHttpClient(deps: {
     method: string = 'GET',
     body?: Record<string, unknown>
   ): Promise<unknown> {
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${deps.apiKey}`,
-      'Content-Type': 'application/json',
-      ...deps.tracking(),
-    };
-
-    const init: {
-      method: string;
-      headers: Record<string, string>;
-      body?: string;
-    } = {
+    const init: RequestInitLike = {
       method,
-      headers,
+      headers: buildRequestHeaders(deps.apiKey, deps.tracking),
     };
-    if (body && (method === 'POST' || method === 'PATCH')) {
+    if (body && methodSendsBody(method)) {
       init.body = JSON.stringify(body);
     }
 
     const response = await deps.fetch(url, init);
 
     if (!response.ok) {
-      const text = await response.text();
-      throw new HttpError(deps.errorPrefix, response.status, text);
+      throw new HttpError(
+        deps.errorPrefix,
+        response.status,
+        await response.text()
+      );
     }
 
     // 204 / empty / non-JSON → a uniform success marker (matches today's helpers
     // and covers pod-action responses that return no JSON body).
-    if (isJsonContentType(response.headers.get('content-type'))) {
-      return response.json();
-    }
-    return { success: true, status: response.status };
+    return isJsonContentType(response.headers.get('content-type'))
+      ? response.json()
+      : { success: true, status: response.status };
   };
 }

--- a/src/_shared/http.ts
+++ b/src/_shared/http.ts
@@ -1,0 +1,110 @@
+// ============== UNIFIED HTTP CLIENT (REST + Serverless) ==============
+// One authenticated JSON client that replaces the byte-identical
+// `runpodRequest` + `serverlessRequest` helpers. The adapter
+// (src/_shared/backend.ts) resolves the full URL, so this client takes a
+// resolved URL — the old `endpointId`-split shape collapses into the path.
+//
+// GraphQL is intentionally NOT routed through here: it sends no Authorization
+// header and has its own `{data,errors}` envelope + error prefix. It stays a
+// separate helper through Phase A.
+//
+// `fetch` and `tracking` are injected so this is unit-testable offline with no
+// network and no MCP SDK.
+
+type FetchLike = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+  }
+) => Promise<HttpResponseLike>;
+
+interface HttpResponseLike {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+  headers: { get(name: string): string | null };
+}
+
+// Thrown on any non-OK response. Carries `status` + `body` so callers can
+// branch (e.g. create-pod maps a 501 to a clean "CPU pods not yet supported"
+// message) without parsing the message string. Because it still THROWS, loops
+// that count consecutive errors (e.g. stream-job) keep working — a 501 mid-poll
+// is surfaced as an error, not swallowed.
+export class HttpError extends Error {
+  readonly status: number;
+  readonly body: string;
+  constructor(prefix: string, status: number, body: string) {
+    super(`${prefix}: ${status} - ${body}`);
+    this.name = 'HttpError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+// A response whose content-type marks it as JSON — including v2's RFC-9457
+// `application/problem+json` error bodies. We match the `+json`/`/json` shape,
+// NOT the literal substring `application/json` (which `problem+json` does not
+// contain), so v2 error bodies are parsed rather than swallowed.
+function isJsonContentType(contentType: string | null): boolean {
+  if (!contentType) return false;
+  const ct = contentType.toLowerCase();
+  return ct.includes('application/json') || ct.includes('+json');
+}
+
+export interface HttpClient {
+  (
+    url: string,
+    method?: string,
+    body?: Record<string, unknown>
+  ): Promise<unknown>;
+}
+
+export function createHttpClient(deps: {
+  apiKey: string;
+  fetch: FetchLike;
+  tracking: () => Record<string, string>;
+  // Distinct per backend so error messages stay attributable
+  // ("Runpod API Error" / "Runpod Serverless API Error").
+  errorPrefix: string;
+}): HttpClient {
+  return async function request(
+    url: string,
+    method: string = 'GET',
+    body?: Record<string, unknown>
+  ): Promise<unknown> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${deps.apiKey}`,
+      'Content-Type': 'application/json',
+      ...deps.tracking(),
+    };
+
+    const init: {
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    } = {
+      method,
+      headers,
+    };
+    if (body && (method === 'POST' || method === 'PATCH')) {
+      init.body = JSON.stringify(body);
+    }
+
+    const response = await deps.fetch(url, init);
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new HttpError(deps.errorPrefix, response.status, text);
+    }
+
+    // 204 / empty / non-JSON → a uniform success marker (matches today's helpers
+    // and covers pod-action responses that return no JSON body).
+    if (isJsonContentType(response.headers.get('content-type'))) {
+      return response.json();
+    }
+    return { success: true, status: response.status };
+  };
+}

--- a/src/_shared/tracking.ts
+++ b/src/_shared/tracking.ts
@@ -1,0 +1,38 @@
+// ============== CALLER TRACKING (pure header construction) ==============
+// The structured User-Agent + session id that identify the calling MCP client
+// on every outbound API call. Pure functions here so they're unit-testable
+// without the MCP SDK; the SDK-touching part (reading clientInfo off the
+// handshake) stays at the call site and is reduced to plain strings before
+// reaching `buildTrackingHeaders`.
+
+// Sanitizes a value for inclusion in a User-Agent token. RFC 7230 reserves
+// parens and a few other chars; strip them so the structured UA stays
+// parseable, and bound the length so a hostile client can't blow up a header.
+export function sanitizeUaToken(value: string): string {
+  return value.replace(/[()<>@,;:\\"/[\]?={}\s]/g, '_').slice(0, 64);
+}
+
+export interface TrackingInput {
+  // Client identity resolved from the MCP `initialize` handshake's clientInfo,
+  // or the inbound HTTP User-Agent as a fallback (stateless HTTP).
+  clientName?: string;
+  clientVersion?: string;
+  transport: 'stdio' | 'http';
+  serverVersion: string;
+  sessionId: string;
+}
+
+// Builds the `User-Agent` + `X-Runpod-Session-Id` headers. The clientInfo →
+// fallback → 'unknown' resolution is the caller's job (it owns the SDK handle);
+// this function just sanitizes and formats whatever identity it's given.
+export function buildTrackingHeaders(
+  input: TrackingInput
+): Record<string, string> {
+  const name = sanitizeUaToken(input.clientName || 'unknown');
+  const version = sanitizeUaToken(input.clientVersion || 'unknown');
+  const userAgent = `runpod-mcp-server/${input.serverVersion} (caller=mcp; client=${name}; client_version=${version}; transport=${input.transport})`;
+  return {
+    'User-Agent': userAgent,
+    'X-Runpod-Session-Id': input.sessionId,
+  };
+}

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -108,8 +108,8 @@ describe('createHttpClient — request shape', () => {
     }
   });
 
-  it('does NOT serialize a body for GET/DELETE', async () => {
-    for (const method of ['GET', 'DELETE']) {
+  it('does NOT serialize a body for GET/DELETE/PUT (gate is POST/PATCH only)', async () => {
+    for (const method of ['GET', 'DELETE', 'PUT']) {
       const cap: Captured = {};
       const client = createHttpClient({
         apiKey: 'k',
@@ -120,6 +120,36 @@ describe('createHttpClient — request shape', () => {
       await client('http://x/pods', method, { name: 'a' });
       assert.equal(cap.init?.body, undefined, method);
     }
+  });
+
+  it('invokes tracking() on every request (not memoized) — session id stays per-call', async () => {
+    let n = 0;
+    const client = createHttpClient({
+      apiKey: 'k',
+      fetch: fakeFetch(fakeResponse({ jsonBody: {} })),
+      tracking: () => ({ 'X-Runpod-Session-Id': String(++n) }),
+      errorPrefix: 'p',
+    });
+    // capture per call
+    const seen: string[] = [];
+    const capClient = createHttpClient({
+      apiKey: 'k',
+      fetch: async (_url, init) => {
+        seen.push(init.headers['X-Runpod-Session-Id']);
+        return fakeResponse({ jsonBody: {} });
+      },
+      tracking: () => ({ 'X-Runpod-Session-Id': String(++n) }),
+      errorPrefix: 'p',
+    });
+    await client('http://x');
+    await capClient('http://x');
+    await capClient('http://x');
+    assert.equal(seen.length, 2);
+    assert.notEqual(
+      seen[0],
+      seen[1],
+      'tracking must be re-evaluated per request'
+    );
   });
 });
 
@@ -137,17 +167,59 @@ describe('createHttpClient — response handling', () => {
     assert.deepEqual(out, { id: 'p1' });
   });
 
-  it('parses an application/problem+json body (v2 errors are JSON, not swallowed)', async () => {
-    // ok:true here just to prove the +json content-type routes to json(); the
-    // error-status path is covered separately below.
+  it('parses a generic +json vendor content-type on success', async () => {
     const out = await mk(
       fakeResponse({
         status: 200,
-        contentType: 'application/problem+json',
-        jsonBody: { detail: 'x' },
+        contentType: 'application/vnd.api+json',
+        jsonBody: { data: 1 },
       })
     )('http://x');
-    assert.deepEqual(out, { detail: 'x' });
+    assert.deepEqual(out, { data: 1 });
+  });
+
+  it('matches application/json with a charset suffix, case-insensitively', async () => {
+    const a = await mk(
+      fakeResponse({
+        contentType: 'application/json; charset=utf-8',
+        jsonBody: { a: 1 },
+      })
+    )('http://x');
+    assert.deepEqual(a, { a: 1 });
+    const b = await mk(
+      fakeResponse({ contentType: 'Application/JSON', jsonBody: { b: 2 } })
+    )('http://x');
+    assert.deepEqual(b, { b: 2 });
+  });
+
+  it('!ok with problem+json: reads body via .text(), never .json(), surfaces it on HttpError.body', async () => {
+    let jsonCalls = 0;
+    const resp = {
+      ok: false,
+      status: 400,
+      headers: { get: () => 'application/problem+json' },
+      json: async () => {
+        jsonCalls++;
+        return { detail: 'should not be read' };
+      },
+      text: async () => '{"detail":"bad request","status":400}',
+    };
+    const client = createHttpClient({
+      apiKey: 'k',
+      fetch: async () => resp,
+      tracking: noTracking,
+      errorPrefix: 'Runpod API Error',
+    });
+    await assert.rejects(
+      () => client('http://x'),
+      (err: unknown) => {
+        assert.ok(err instanceof HttpError);
+        assert.equal(err.status, 400);
+        assert.equal(err.body, '{"detail":"bad request","status":400}');
+        return true;
+      }
+    );
+    assert.equal(jsonCalls, 0, 'error path must not call .json()');
   });
 
   it('204 / empty / non-JSON → { success: true, status }', async () => {
@@ -170,6 +242,7 @@ describe('createHttpClient — response handling', () => {
       () => client('http://x'),
       (err: unknown) => {
         assert.ok(err instanceof HttpError);
+        assert.equal(err.name, 'HttpError');
         assert.equal(err.status, 404);
         assert.equal(err.body, 'not found');
         assert.match(err.message, /^Runpod API Error: 404 - not found$/);
@@ -208,6 +281,27 @@ describe('tracking headers', () => {
   it('sanitizeUaToken strips reserved chars and bounds length', () => {
     assert.equal(sanitizeUaToken('claude (code)'), 'claude__code_');
     assert.equal(sanitizeUaToken('a'.repeat(100)).length, 64);
+  });
+
+  it('sanitizeUaToken: 64 passes unchanged, 65 truncates to 64 (boundary)', () => {
+    assert.equal(sanitizeUaToken('a'.repeat(64)), 'a'.repeat(64));
+    assert.equal(sanitizeUaToken('a'.repeat(65)).length, 64);
+  });
+
+  it('sanitizeUaToken: all-reserved → underscores, empty → empty', () => {
+    assert.equal(sanitizeUaToken('(),;'), '____');
+    assert.equal(sanitizeUaToken(''), '');
+  });
+
+  it('uses unknown for an empty-string clientName/clientVersion (|| not ??)', () => {
+    const h = buildTrackingHeaders({
+      clientName: '',
+      clientVersion: '',
+      transport: 'stdio',
+      serverVersion: '1.0.0',
+      sessionId: 's',
+    });
+    assert.match(h['User-Agent'], /client=unknown; client_version=unknown/);
   });
 
   it('builds the structured UA + session id', () => {

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,0 +1,239 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createHttpClient, HttpError } from '../src/_shared/http.js';
+import {
+  sanitizeUaToken,
+  buildTrackingHeaders,
+} from '../src/_shared/tracking.js';
+
+// ---- fake response/fetch builders (no network) ----
+interface FakeResponseOpts {
+  ok?: boolean;
+  status?: number;
+  contentType?: string | null;
+  jsonBody?: unknown;
+  textBody?: string;
+}
+
+function fakeResponse(opts: FakeResponseOpts) {
+  const status = opts.status ?? 200;
+  // Respect an explicit `contentType: null`; only default when the key is absent.
+  const contentType =
+    'contentType' in opts ? opts.contentType : 'application/json';
+  return {
+    ok: opts.ok ?? (status >= 200 && status < 300),
+    status,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? (contentType ?? null) : null,
+    },
+    json: async () => opts.jsonBody,
+    text: async () => opts.textBody ?? '',
+  };
+}
+
+type Captured = {
+  url?: string;
+  init?: { method: string; headers: Record<string, string>; body?: string };
+};
+
+function fakeFetch(resp: ReturnType<typeof fakeResponse>, captured?: Captured) {
+  return async (
+    url: string,
+    init: { method: string; headers: Record<string, string>; body?: string }
+  ) => {
+    if (captured) {
+      captured.url = url;
+      captured.init = init;
+    }
+    return resp;
+  };
+}
+
+const noTracking = () => ({});
+
+describe('createHttpClient — request shape', () => {
+  it('passes the resolved URL through unchanged', async () => {
+    const cap: Captured = {};
+    const client = createHttpClient({
+      apiKey: 'k',
+      fetch: fakeFetch(fakeResponse({ jsonBody: {} }), cap),
+      tracking: noTracking,
+      errorPrefix: 'Runpod API Error',
+    });
+    await client('https://rest.runpod.io/v1/pods');
+    assert.equal(cap.url, 'https://rest.runpod.io/v1/pods');
+  });
+
+  it('sets Authorization bearer + Content-Type + tracking headers', async () => {
+    const cap: Captured = {};
+    const client = createHttpClient({
+      apiKey: 'rpa_abc',
+      fetch: fakeFetch(fakeResponse({ jsonBody: {} }), cap),
+      tracking: () => ({ 'User-Agent': 'ua/1', 'X-Runpod-Session-Id': 'sid' }),
+      errorPrefix: 'Runpod API Error',
+    });
+    await client('http://x/pods');
+    assert.equal(cap.init?.headers.Authorization, 'Bearer rpa_abc');
+    assert.equal(cap.init?.headers['Content-Type'], 'application/json');
+    assert.equal(cap.init?.headers['User-Agent'], 'ua/1');
+    assert.equal(cap.init?.headers['X-Runpod-Session-Id'], 'sid');
+  });
+
+  it('defaults method to GET and sends no body', async () => {
+    const cap: Captured = {};
+    const client = createHttpClient({
+      apiKey: 'k',
+      fetch: fakeFetch(fakeResponse({ jsonBody: {} }), cap),
+      tracking: noTracking,
+      errorPrefix: 'p',
+    });
+    await client('http://x/pods');
+    assert.equal(cap.init?.method, 'GET');
+    assert.equal(cap.init?.body, undefined);
+  });
+
+  it('serializes body only for POST/PATCH', async () => {
+    for (const method of ['POST', 'PATCH']) {
+      const cap: Captured = {};
+      const client = createHttpClient({
+        apiKey: 'k',
+        fetch: fakeFetch(fakeResponse({ jsonBody: {} }), cap),
+        tracking: noTracking,
+        errorPrefix: 'p',
+      });
+      await client('http://x/pods', method, { name: 'a' });
+      assert.equal(cap.init?.body, JSON.stringify({ name: 'a' }), method);
+    }
+  });
+
+  it('does NOT serialize a body for GET/DELETE', async () => {
+    for (const method of ['GET', 'DELETE']) {
+      const cap: Captured = {};
+      const client = createHttpClient({
+        apiKey: 'k',
+        fetch: fakeFetch(fakeResponse({ jsonBody: {} }), cap),
+        tracking: noTracking,
+        errorPrefix: 'p',
+      });
+      await client('http://x/pods', method, { name: 'a' });
+      assert.equal(cap.init?.body, undefined, method);
+    }
+  });
+});
+
+describe('createHttpClient — response handling', () => {
+  const mk = (resp: ReturnType<typeof fakeResponse>) =>
+    createHttpClient({
+      apiKey: 'k',
+      fetch: fakeFetch(resp),
+      tracking: noTracking,
+      errorPrefix: 'Runpod API Error',
+    });
+
+  it('parses an application/json body', async () => {
+    const out = await mk(fakeResponse({ jsonBody: { id: 'p1' } }))('http://x');
+    assert.deepEqual(out, { id: 'p1' });
+  });
+
+  it('parses an application/problem+json body (v2 errors are JSON, not swallowed)', async () => {
+    // ok:true here just to prove the +json content-type routes to json(); the
+    // error-status path is covered separately below.
+    const out = await mk(
+      fakeResponse({
+        status: 200,
+        contentType: 'application/problem+json',
+        jsonBody: { detail: 'x' },
+      })
+    )('http://x');
+    assert.deepEqual(out, { detail: 'x' });
+  });
+
+  it('204 / empty / non-JSON → { success: true, status }', async () => {
+    const out = await mk(fakeResponse({ status: 204, contentType: null }))(
+      'http://x'
+    );
+    assert.deepEqual(out, { success: true, status: 204 });
+
+    const out2 = await mk(
+      fakeResponse({ status: 200, contentType: 'text/plain' })
+    )('http://x');
+    assert.deepEqual(out2, { success: true, status: 200 });
+  });
+
+  it('!ok → throws HttpError carrying status + body + prefix', async () => {
+    const client = mk(
+      fakeResponse({ status: 404, ok: false, textBody: 'not found' })
+    );
+    await assert.rejects(
+      () => client('http://x'),
+      (err: unknown) => {
+        assert.ok(err instanceof HttpError);
+        assert.equal(err.status, 404);
+        assert.equal(err.body, 'not found');
+        assert.match(err.message, /^Runpod API Error: 404 - not found$/);
+        return true;
+      }
+    );
+  });
+
+  it('501 throws an HttpError with status 501 (so create-pod can branch, stream-job still counts it)', async () => {
+    const client = mk(
+      fakeResponse({ status: 501, ok: false, textBody: 'not implemented' })
+    );
+    await assert.rejects(
+      () => client('http://x'),
+      (err: unknown) => err instanceof HttpError && err.status === 501
+    );
+  });
+
+  it('error prefix is configurable per client (serverless vs rest)', async () => {
+    const client = createHttpClient({
+      apiKey: 'k',
+      fetch: fakeFetch(
+        fakeResponse({ status: 500, ok: false, textBody: 'boom' })
+      ),
+      tracking: noTracking,
+      errorPrefix: 'Runpod Serverless API Error',
+    });
+    await assert.rejects(
+      () => client('http://x'),
+      /Runpod Serverless API Error: 500 - boom$/
+    );
+  });
+});
+
+describe('tracking headers', () => {
+  it('sanitizeUaToken strips reserved chars and bounds length', () => {
+    assert.equal(sanitizeUaToken('claude (code)'), 'claude__code_');
+    assert.equal(sanitizeUaToken('a'.repeat(100)).length, 64);
+  });
+
+  it('builds the structured UA + session id', () => {
+    const h = buildTrackingHeaders({
+      clientName: 'Cursor',
+      clientVersion: '1.2.3',
+      transport: 'stdio',
+      serverVersion: '1.3.0',
+      sessionId: 'sid-1',
+    });
+    assert.equal(
+      h['User-Agent'],
+      'runpod-mcp-server/1.3.0 (caller=mcp; client=Cursor; client_version=1.2.3; transport=stdio)'
+    );
+    assert.equal(h['X-Runpod-Session-Id'], 'sid-1');
+  });
+
+  it('falls back to unknown when client identity is missing', () => {
+    const h = buildTrackingHeaders({
+      transport: 'http',
+      serverVersion: 'dev',
+      sessionId: 's',
+    });
+    assert.match(
+      h['User-Agent'],
+      /client=unknown; client_version=unknown; transport=http/
+    );
+  });
+});


### PR DESCRIPTION
**Stacked draft — do not merge.** Base = `v2/phase-a1-adapter-core` (PR #34). Implements **Phase A / Step A3**.

## What this is
The unified authenticated JSON client that replaces the byte-identical `runpodRequest` + `serverlessRequest`, plus a pure home for tracking headers. **Additive** — not wired into `tools.ts` yet (A4/PR3 does that), so v1 behavior is unchanged.

## Contents
- **`src/_shared/http.ts` — `createHttpClient({apiKey, fetch, tracking, errorPrefix})`**: takes a fully-resolved URL (the adapter builds base+path, collapsing the old `endpointId`-split), injected `fetch` so it's offline-testable.
- **`HttpError(status, body)`** — thrown on `!ok`. **Refines the PLAN's provisional 501 contract:** instead of *returning* `{unsupported}` (which would defang `stream-job`'s consecutive-error counter — the A4 risk), it **throws** a typed error carrying `.status`, so `create-pod` (C2) branches on 501 while `stream-job` still counts it. Best of both.
- Content-type matches the **`+json` suffix** so v2's RFC-9457 `application/problem+json` errors are parsed, not swallowed; `204`/empty/non-JSON → `{success:true,status}`.
- **GraphQL intentionally NOT merged** (no auth header, own `{data,errors}` envelope) — stays separate through Phase A.
- **`src/_shared/tracking.ts`** — pure `sanitizeUaToken` + `buildTrackingHeaders` (SDK-free; the home A4 wires the handlers into).

## Tests / checks
- 14 new offline tests (injected fetch, no network/SDK): request shape (URL/headers/method/body), response handling (json, problem+json, 204/empty, HttpError w/ status+body, 501, per-client prefix), tracking header construction + fallback.
- **70 total pass** · `tsc`/`eslint`/`tsup` clean.

## Deviation note (intentional)
The 501 handling deviates from PLAN A3's "returns {unsupported:true}" — see HttpError rationale above. This is the explicitly-"provisional" contract being resolved in favor of the design that doesn't break stream-job. PLAN can be updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)