### PR TITLE
[Phase B · PR4] v2 request mappers + v2 resolveBackend descriptors (B1/B2/B3)

### DIFF
--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -291,6 +291,66 @@ const V2_MAPPERS: Partial<
   registries: { create: identity, update: identity },
 };
 
+// The unwrap closure is built once in resolveBackend and threaded into whichever
+// builder runs, so the per-version builders stay free of unwrap plumbing.
+type Unwrap = Backend['unwrap'];
+
+// jobs/endpoints never reach here (pinned v1 by resolveVersion). Catalog v2 is
+// REST (not GraphQL); CRUD resources use their v2 paths + body mappers.
+function buildV2Backend(resource: Resource, env: Env, unwrap: Unwrap): Backend {
+  const paths = V2_REST_PATHS[resource];
+  if (!paths) throw new Error(`no v2 REST paths for resource "${resource}"`);
+  const mappers = V2_MAPPERS[resource];
+  return {
+    kind: 'rest',
+    version: 'v2',
+    base: restV2Base(env),
+    list: paths.list,
+    get: paths.get,
+    unwrap,
+    mapCreate: mappers?.create ?? identity,
+    mapUpdate: mappers?.update ?? identity,
+  };
+}
+
+function buildV1Backend(resource: Resource, env: Env, unwrap: Unwrap): Backend {
+  // jobs: serverless runtime base; no list/get/path table entry.
+  if (resource === 'jobs') {
+    return {
+      kind: 'rest',
+      version: 'v1',
+      base: serverlessBase(env),
+      unwrap,
+      mapCreate: identity,
+      mapUpdate: identity,
+    };
+  }
+  // v1 catalog is GraphQL via a separate helper (kept out of the unified REST
+  // client through Phase A); folds into REST at Step B5.
+  if (CATALOG.has(resource)) {
+    return {
+      kind: 'graphql',
+      version: 'v1',
+      base: env.RUNPOD_PUBLIC_GRAPHQL_URL ?? 'https://api.runpod.io/graphql',
+      unwrap,
+      mapCreate: identity,
+      mapUpdate: identity,
+    };
+  }
+  const paths = V1_REST_PATHS[resource];
+  if (!paths) throw new Error(`no v1 REST paths for resource "${resource}"`);
+  return {
+    kind: 'rest',
+    version: 'v1',
+    base: restV1Base(env),
+    list: paths.list,
+    get: paths.get,
+    unwrap,
+    mapCreate: identity,
+    mapUpdate: identity,
+  };
+}
+
 export function resolveBackend(opts: {
   resource: Resource;
   env: Env;
@@ -299,65 +359,8 @@ export function resolveBackend(opts: {
 }): Backend {
   const { resource, env } = opts;
   const version = resolveVersion(opts);
-  const unwrap = (raw: unknown): unknown[] =>
-    unwrapList(resource, version, raw);
-
-  if (version === 'v2') {
-    // jobs/endpoints never reach here (pinned v1 by resolveVersion). Catalog v2
-    // is REST (not GraphQL); CRUD resources use their v2 paths + body mappers.
-    const v2Paths = V2_REST_PATHS[resource];
-    if (!v2Paths) {
-      throw new Error(`no v2 REST paths for resource "${resource}"`);
-    }
-    const mappers = V2_MAPPERS[resource];
-    return {
-      kind: 'rest',
-      version,
-      base: restV2Base(env),
-      list: v2Paths.list,
-      get: v2Paths.get,
-      unwrap,
-      mapCreate: mappers?.create ?? identity,
-      mapUpdate: mappers?.update ?? identity,
-    };
-  }
-
-  // ---- v1 ----
-  if (resource === 'jobs') {
-    return {
-      kind: 'rest',
-      version,
-      base: serverlessBase(env),
-      unwrap,
-      mapCreate: identity,
-      mapUpdate: identity,
-    };
-  }
-  if (CATALOG.has(resource)) {
-    // v1 catalog is GraphQL via a separate helper (kept out of the unified REST
-    // client through Phase A); folds into REST at Step B5.
-    return {
-      kind: 'graphql',
-      version,
-      base: env.RUNPOD_PUBLIC_GRAPHQL_URL ?? 'https://api.runpod.io/graphql',
-      unwrap,
-      mapCreate: identity,
-      mapUpdate: identity,
-    };
-  }
-
-  const paths = V1_REST_PATHS[resource];
-  if (!paths) {
-    throw new Error(`no v1 REST paths for resource "${resource}"`);
-  }
-  return {
-    kind: 'rest',
-    version,
-    base: restV1Base(env),
-    list: paths.list,
-    get: paths.get,
-    unwrap,
-    mapCreate: identity,
-    mapUpdate: identity,
-  };
+  const unwrap: Unwrap = (raw) => unwrapList(resource, version, raw);
+  return version === 'v2'
+    ? buildV2Backend(resource, env, unwrap)
+    : buildV1Backend(resource, env, unwrap);
 }

--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -8,6 +8,13 @@
 // with no network and no MCP SDK. The HTTP client (src/_shared/http.ts) and the
 // per-resource tool handlers (src/tools/<resource>.ts) consume this.
 
+import {
+  mapPodCreateToV2,
+  mapPodUpdateToV2,
+  mapTemplateCreateToV2,
+  mapNetworkVolumeCreateToV2,
+} from './mappers.js';
+
 // One canonical resource union used by unwrapList, resolveVersion, and
 // resolveBackend alike — so the steps don't each invent a spelling. The v2
 // list-envelope key happens to equal the resource name.
@@ -235,6 +242,55 @@ const CATALOG: ReadonlySet<Resource> = new Set<Resource>([
   'dataCenters',
 ]);
 
+// v2 REST paths (the control-plane resources). Note the renames vs v1:
+// network-volumes (hyphen), registries (was containerregistryauth), catalog/*.
+// Catalog `datacenters` is intentionally NOT hyphenated (matches the spec).
+const V2_REST_PATHS: Partial<
+  Record<Resource, { list: string; get?: (id: string) => string }>
+> = {
+  pods: { list: '/v2/pods', get: (id) => `/v2/pods/${id}` },
+  templates: { list: '/v2/templates', get: (id) => `/v2/templates/${id}` },
+  networkVolumes: {
+    list: '/v2/network-volumes',
+    get: (id) => `/v2/network-volumes/${id}`,
+  },
+  registries: { list: '/v2/registries', get: (id) => `/v2/registries/${id}` },
+  gpus: { list: '/v2/catalog/gpus', get: (id) => `/v2/catalog/gpus/${id}` },
+  cpus: { list: '/v2/catalog/cpus' },
+  dataCenters: { list: '/v2/catalog/datacenters' },
+};
+
+// v2 request-body mappers per resource (identity where v1==v2, e.g. registries).
+const V2_MAPPERS: Partial<
+  Record<
+    Resource,
+    {
+      create: (body: unknown) => unknown;
+      update: (body: unknown) => unknown;
+    }
+  >
+> = {
+  pods: {
+    create: (b) =>
+      mapPodCreateToV2(b as Parameters<typeof mapPodCreateToV2>[0]),
+    update: (b) =>
+      mapPodUpdateToV2(b as Parameters<typeof mapPodUpdateToV2>[0]),
+  },
+  templates: {
+    create: (b) =>
+      mapTemplateCreateToV2(b as Parameters<typeof mapTemplateCreateToV2>[0]),
+    update: identity,
+  },
+  networkVolumes: {
+    create: (b) =>
+      mapNetworkVolumeCreateToV2(
+        b as Parameters<typeof mapNetworkVolumeCreateToV2>[0]
+      ),
+    update: identity,
+  },
+  registries: { create: identity, update: identity },
+};
+
 export function resolveBackend(opts: {
   resource: Resource;
   env: Env;
@@ -247,11 +303,23 @@ export function resolveBackend(opts: {
     unwrapList(resource, version, raw);
 
   if (version === 'v2') {
-    // Filled in Phase B (B2/B1/B3/B5). Throwing here keeps the v1-only Phase A
-    // honest: nothing routes to v2 until the mappers + paths exist.
-    throw new Error(
-      `v2 backend for "${resource}" not implemented until Phase B`
-    );
+    // jobs/endpoints never reach here (pinned v1 by resolveVersion). Catalog v2
+    // is REST (not GraphQL); CRUD resources use their v2 paths + body mappers.
+    const v2Paths = V2_REST_PATHS[resource];
+    if (!v2Paths) {
+      throw new Error(`no v2 REST paths for resource "${resource}"`);
+    }
+    const mappers = V2_MAPPERS[resource];
+    return {
+      kind: 'rest',
+      version,
+      base: restV2Base(env),
+      list: v2Paths.list,
+      get: v2Paths.get,
+      unwrap,
+      mapCreate: mappers?.create ?? identity,
+      mapUpdate: mappers?.update ?? identity,
+    };
   }
 
   // ---- v1 ----

--- a/src/_shared/mappers.ts
+++ b/src/_shared/mappers.ts
@@ -1,0 +1,139 @@
+// ============== v1 → v2 REQUEST BODY MAPPERS ==============
+// Pure functions that translate the v1-shaped tool params (what the MCP tool
+// schemas accept today) into v2 REST request bodies. Isolated here so the v2
+// shape is a one-file change when the spec moves.
+//
+// ⚠️ SPEC IS MID-FLIGHT (see PLAN.md Part 7/8). These mappers target the current
+// v2 dev spec snapshot and are pinned by committed fixtures under tests/fixtures.
+// Known pending upstream changes that will require updating these + the fixtures:
+//   - `dataCenter` (scalar) may revert to `dataCenterIds` (array)
+//   - `cloud` enum may drop `ALL`
+//   - template `category` may become optional / be removed
+// When the live spec changes, update the mapper AND its fixture in one commit.
+
+// v1 params accepted by the create-pod / update-pod tool schemas (the fields the
+// mapper knows how to translate). Unknown keys are intentionally dropped.
+interface V1PodParams {
+  name?: string;
+  imageName?: string;
+  cloudType?: 'SECURE' | 'COMMUNITY';
+  gpuTypeIds?: string[];
+  gpuCount?: number;
+  containerDiskInGb?: number;
+  volumeInGb?: number;
+  volumeMountPath?: string;
+  ports?: string[];
+  env?: Record<string, string>;
+  dataCenterIds?: string[];
+}
+
+// Drop undefined entries so we never emit explicit `undefined`/`null` the API
+// would reject; keeps the body minimal and the fixtures clean.
+function compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as Partial<T>;
+}
+
+// ---- ContainerConfig flatten shared by pod + template create/update ----
+function containerConfigToV2(p: {
+  imageName?: string;
+  containerDiskInGb?: number;
+  volumeInGb?: number;
+  volumeMountPath?: string;
+  ports?: string[];
+  env?: Record<string, string>;
+}): Record<string, unknown> {
+  const out: Record<string, unknown> = compact({
+    image: p.imageName,
+    disk: p.containerDiskInGb,
+    ports: p.ports,
+    env: p.env,
+  });
+  // volumeInGb / volumeMountPath → mounts.persistent.{size,path}
+  if (p.volumeInGb !== undefined || p.volumeMountPath !== undefined) {
+    const persistent = compact({
+      size: p.volumeInGb,
+      path: p.volumeMountPath,
+    });
+    out.mounts = { persistent };
+  }
+  return out;
+}
+
+export function mapPodCreateToV2(params: V1PodParams): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    ...containerConfigToV2(params),
+    ...compact({
+      name: params.name,
+      cloud: params.cloudType,
+      // array → scalar: v2 takes a single GPU type id
+      dataCenter: params.dataCenterIds?.[0],
+    }),
+  };
+  // gpuTypeIds[] + gpuCount → gpu: { id, count }
+  if (params.gpuTypeIds?.length || params.gpuCount !== undefined) {
+    body.gpu = compact({
+      id: params.gpuTypeIds?.[0],
+      count: params.gpuCount,
+    });
+  }
+  return body;
+}
+
+export function mapPodUpdateToV2(params: V1PodParams): Record<string, unknown> {
+  // Update has no gpu/cloud/dataCenter; just name + ContainerConfig fields.
+  return {
+    ...containerConfigToV2(params),
+    ...compact({ name: params.name }),
+  };
+}
+
+// ---- Network volume: dataCenterId → dataCenter (only field change) ----
+interface V1NetworkVolumeCreate {
+  name?: string;
+  size?: number;
+  dataCenterId?: string;
+}
+export function mapNetworkVolumeCreateToV2(
+  params: V1NetworkVolumeCreate
+): Record<string, unknown> {
+  return compact({
+    name: params.name,
+    size: params.size,
+    dataCenter: params.dataCenterId,
+  });
+}
+
+// ---- Template: imageName→image, isServerless→serverless, ContainerConfig flatten,
+// drop readme/dockerEntrypoint/dockerStartCmd (no v2 equivalent; args collapse is
+// lossy — see PLAN B3, deferred to a follow-up that decides join semantics). ----
+interface V1TemplateCreate {
+  name?: string;
+  imageName?: string;
+  isServerless?: boolean;
+  ports?: string[];
+  env?: Record<string, string>;
+  containerDiskInGb?: number;
+  volumeInGb?: number;
+  volumeMountPath?: string;
+}
+export function mapTemplateCreateToV2(
+  params: V1TemplateCreate
+): Record<string, unknown> {
+  return {
+    ...containerConfigToV2(params),
+    ...compact({
+      name: params.name,
+      serverless: params.isServerless,
+    }),
+  };
+}
+
+// Registry create is unchanged between v1 and v2 (name/username/password) →
+// identity. Exposed for symmetry so the descriptor table is uniform.
+export function identityMapper(body: unknown): unknown {
+  return body;
+}

--- a/src/_shared/mappers.ts
+++ b/src/_shared/mappers.ts
@@ -8,7 +8,8 @@
 // Known pending upstream changes that will require updating these + the fixtures:
 //   - `dataCenter` (scalar) may revert to `dataCenterIds` (array)
 //   - `cloud` enum may drop `ALL`
-//   - template `category` may become optional / be removed
+//   - template `category` may become optional / be removed (we currently emit it
+//     with an NVIDIA default since the committed spec marks it required)
 // When the live spec changes, update the mapper AND its fixture in one commit.
 
 // v1 params accepted by the create-pod / update-pod tool schemas (the fields the
@@ -52,13 +53,15 @@ function containerConfigToV2(p: {
     ports: p.ports,
     env: p.env,
   });
-  // volumeInGb / volumeMountPath → mounts.persistent.{size,path}
-  if (p.volumeInGb !== undefined || p.volumeMountPath !== undefined) {
-    const persistent = compact({
-      size: p.volumeInGb,
-      path: p.volumeMountPath,
-    });
-    out.mounts = { persistent };
+  // volumeInGb / volumeMountPath → mounts.persistent.{size,path}.
+  // v2 PersistentMount requires BOTH size and path (additionalProperties:false,
+  // 422 on a partial). So only emit the mount when both are present; a partial
+  // v1 input (size-only or path-only) is dropped rather than producing a body
+  // the API rejects. (Tool-schema validation should require both together.)
+  if (p.volumeInGb !== undefined && p.volumeMountPath !== undefined) {
+    out.mounts = {
+      persistent: { size: p.volumeInGb, path: p.volumeMountPath },
+    };
   }
   return out;
 }
@@ -73,12 +76,12 @@ export function mapPodCreateToV2(params: V1PodParams): Record<string, unknown> {
       dataCenter: params.dataCenterIds?.[0],
     }),
   };
-  // gpuTypeIds[] + gpuCount → gpu: { id, count }
-  if (params.gpuTypeIds?.length || params.gpuCount !== undefined) {
-    body.gpu = compact({
-      id: params.gpuTypeIds?.[0],
-      count: params.gpuCount,
-    });
+  // gpuTypeIds[] + gpuCount → gpu: { id, count }. v2 GpuConfig requires `id`, so
+  // only emit `gpu` when a concrete id is present — a count-only input would
+  // produce an idless gpu the API rejects (422). count is optional (defaults 1).
+  const gpuId = params.gpuTypeIds?.[0];
+  if (gpuId !== undefined) {
+    body.gpu = compact({ id: gpuId, count: params.gpuCount });
   }
   return body;
 }
@@ -119,6 +122,10 @@ interface V1TemplateCreate {
   containerDiskInGb?: number;
   volumeInGb?: number;
   volumeMountPath?: string;
+  // v2 CreateTemplateRequest requires `category` (CPU/NVIDIA/AMD). The v1 tool
+  // has no such field; default to NVIDIA (the documented default) so the body is
+  // valid, and accept an explicit override once the tool schema exposes it.
+  category?: 'CPU' | 'NVIDIA' | 'AMD';
 }
 export function mapTemplateCreateToV2(
   params: V1TemplateCreate
@@ -129,6 +136,8 @@ export function mapTemplateCreateToV2(
       name: params.name,
       serverless: params.isServerless,
     }),
+    // Required by v2 — always emit, defaulting to NVIDIA.
+    category: params.category ?? 'NVIDIA',
   };
 }
 

--- a/src/_shared/mappers.ts
+++ b/src/_shared/mappers.ts
@@ -38,6 +38,21 @@ function compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return out as Partial<T>;
 }
 
+// volumeInGb / volumeMountPath → mounts.persistent.{size,path}.
+// v2 PersistentMount requires BOTH size and path (additionalProperties:false,
+// 422 on a partial). So only emit the mount when both are present; a partial
+// v1 input (size-only or path-only) yields `undefined` and is dropped rather
+// than producing a body the API rejects. (Tool-schema validation should require
+// both together.)
+type PersistentMount = { persistent: { size: number; path: string } };
+function persistentMount(
+  size?: number,
+  path?: string
+): PersistentMount | undefined {
+  if (size === undefined || path === undefined) return undefined;
+  return { persistent: { size, path } };
+}
+
 // ---- ContainerConfig flatten shared by pod + template create/update ----
 function containerConfigToV2(p: {
   imageName?: string;
@@ -47,43 +62,36 @@ function containerConfigToV2(p: {
   ports?: string[];
   env?: Record<string, string>;
 }): Record<string, unknown> {
-  const out: Record<string, unknown> = compact({
+  return compact({
     image: p.imageName,
     disk: p.containerDiskInGb,
     ports: p.ports,
     env: p.env,
+    mounts: persistentMount(p.volumeInGb, p.volumeMountPath),
   });
-  // volumeInGb / volumeMountPath → mounts.persistent.{size,path}.
-  // v2 PersistentMount requires BOTH size and path (additionalProperties:false,
-  // 422 on a partial). So only emit the mount when both are present; a partial
-  // v1 input (size-only or path-only) is dropped rather than producing a body
-  // the API rejects. (Tool-schema validation should require both together.)
-  if (p.volumeInGb !== undefined && p.volumeMountPath !== undefined) {
-    out.mounts = {
-      persistent: { size: p.volumeInGb, path: p.volumeMountPath },
-    };
-  }
-  return out;
+}
+
+// gpuTypeIds[] + gpuCount → gpu: { id, count }. v2 GpuConfig requires `id`, so
+// return undefined for a count-only input — an idless gpu would be rejected
+// (422). count is optional (defaults to 1 server-side).
+function gpuConfigToV2(
+  gpuTypeIds?: string[],
+  gpuCount?: number
+): Record<string, unknown> | undefined {
+  const id = gpuTypeIds?.[0];
+  if (id === undefined) return undefined;
+  return compact({ id, count: gpuCount });
 }
 
 export function mapPodCreateToV2(params: V1PodParams): Record<string, unknown> {
-  const body: Record<string, unknown> = {
+  return compact({
     ...containerConfigToV2(params),
-    ...compact({
-      name: params.name,
-      cloud: params.cloudType,
-      // array → scalar: v2 takes a single GPU type id
-      dataCenter: params.dataCenterIds?.[0],
-    }),
-  };
-  // gpuTypeIds[] + gpuCount → gpu: { id, count }. v2 GpuConfig requires `id`, so
-  // only emit `gpu` when a concrete id is present — a count-only input would
-  // produce an idless gpu the API rejects (422). count is optional (defaults 1).
-  const gpuId = params.gpuTypeIds?.[0];
-  if (gpuId !== undefined) {
-    body.gpu = compact({ id: gpuId, count: params.gpuCount });
-  }
-  return body;
+    name: params.name,
+    cloud: params.cloudType,
+    // array → scalar: v2 takes a single GPU type id / data center
+    dataCenter: params.dataCenterIds?.[0],
+    gpu: gpuConfigToV2(params.gpuTypeIds, params.gpuCount),
+  });
 }
 
 export function mapPodUpdateToV2(params: V1PodParams): Record<string, unknown> {

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -533,6 +533,26 @@ describe('resolveBackend (v2 descriptors)', () => {
     assert.deepEqual(reg.mapCreate(body), body); // identity
   });
 
+  it('per-resource override yields a v2 descriptor while siblings stay v1', () => {
+    const env = { RUNPOD_REST_VERSION: 'v1', RUNPOD_REST_VERSION_PODS: 'v2' };
+    const pods = resolveBackend({ resource: 'pods', env, ctx: stdio });
+    assert.equal(pods.version, 'v2');
+    assert.equal(pods.base, 'https://v2-rest.runpod.io/v2');
+    assert.equal(pods.list, '/v2/pods');
+    assert.equal(
+      (pods.mapCreate({ imageName: 'i' }) as Record<string, unknown>).image,
+      'i'
+    );
+    const templates = resolveBackend({
+      resource: 'templates',
+      env,
+      ctx: stdio,
+    });
+    assert.equal(templates.version, 'v1');
+    assert.equal(templates.base, 'https://rest.runpod.io/v1');
+    assert.equal(templates.list, '/templates');
+  });
+
   it('jobs/endpoints stay v1 even under RUNPOD_REST_VERSION=v2', () => {
     const jobs = resolveBackend({ resource: 'jobs', env: v2env, ctx: stdio });
     assert.equal(jobs.version, 'v1');

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -450,8 +450,7 @@ describe('resolveBackend (v1)', () => {
     }
   });
 
-  it('forwards v2Available through to resolveVersion (auto+stdio)', () => {
-    // auto + no v2Available → v1 → resolves (does not throw)
+  it('auto + no v2Available → v1 descriptor (does not throw)', () => {
     assert.doesNotThrow(() =>
       resolveBackend({
         resource: 'pods',
@@ -459,28 +458,91 @@ describe('resolveBackend (v1)', () => {
         ctx: stdio,
       })
     );
-    // auto + v2Available:true → v2 → throws (Phase B not implemented)
-    assert.throws(
-      () =>
-        resolveBackend({
-          resource: 'pods',
-          env: { RUNPOD_REST_VERSION: 'auto' },
-          ctx: stdio,
-          v2Available: true,
-        }),
-      /not implemented until Phase B/
-    );
   });
 
-  it('v2 resolution throws until Phase B (keeps Phase A v1-only honest)', () => {
-    assert.throws(
-      () =>
-        resolveBackend({
-          resource: 'pods',
-          env: { RUNPOD_REST_VERSION: 'v2' },
-          ctx: stdio,
-        }),
-      /not implemented until Phase B/
-    );
+  it('forwards v2Available through to resolveVersion (auto+stdio→v2 descriptor)', () => {
+    const b = resolveBackend({
+      resource: 'pods',
+      env: { RUNPOD_REST_VERSION: 'auto' },
+      ctx: stdio,
+      v2Available: true,
+    });
+    assert.equal(b.version, 'v2');
+    assert.equal(b.base, 'https://v2-rest.runpod.io/v2');
+  });
+});
+
+describe('resolveBackend (v2 descriptors)', () => {
+  const stdio = { transport: 'stdio' as const };
+  const v2env = { RUNPOD_REST_VERSION: 'v2' };
+
+  it('exact v2 paths per resource (renames + catalog)', () => {
+    const expect: Array<[Resource, string, string | undefined]> = [
+      ['pods', '/v2/pods', '/v2/pods/X'],
+      ['templates', '/v2/templates', '/v2/templates/X'],
+      ['networkVolumes', '/v2/network-volumes', '/v2/network-volumes/X'],
+      ['registries', '/v2/registries', '/v2/registries/X'],
+      ['gpus', '/v2/catalog/gpus', '/v2/catalog/gpus/X'],
+      ['cpus', '/v2/catalog/cpus', undefined],
+      ['dataCenters', '/v2/catalog/datacenters', undefined],
+    ];
+    for (const [resource, list, get] of expect) {
+      const b = resolveBackend({ resource, env: v2env, ctx: stdio });
+      assert.equal(b.version, 'v2', `${resource} version`);
+      assert.equal(b.base, 'https://v2-rest.runpod.io/v2', `${resource} base`);
+      assert.equal(b.kind, 'rest', `${resource} kind (catalog is REST in v2)`);
+      assert.equal(b.list, list, `${resource} list`);
+      assert.equal(get ? b.get!('X') : b.get, get, `${resource} get`);
+    }
+  });
+
+  it('v2 base is env-overridable', () => {
+    const b = resolveBackend({
+      resource: 'pods',
+      env: {
+        RUNPOD_REST_VERSION: 'v2',
+        RUNPOD_REST_V2_API_URL: 'http://local/v2',
+      },
+      ctx: stdio,
+    });
+    assert.equal(b.base, 'http://local/v2');
+  });
+
+  it('v2 unwrap pulls the envelope key', () => {
+    const b = resolveBackend({ resource: 'pods', env: v2env, ctx: stdio });
+    assert.deepEqual(b.unwrap({ pods: [{ id: 'p' }] }), [{ id: 'p' }]);
+    const t = resolveBackend({ resource: 'templates', env: v2env, ctx: stdio });
+    assert.deepEqual(t.unwrap({ templates: [1, 2] }), [1, 2]);
+  });
+
+  it('v2 mapCreate is wired (pods remap; registries identity)', () => {
+    const pods = resolveBackend({ resource: 'pods', env: v2env, ctx: stdio });
+    const mapped = pods.mapCreate({ imageName: 'i' }) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(mapped.image, 'i');
+    assert.equal('imageName' in mapped, false);
+
+    const reg = resolveBackend({
+      resource: 'registries',
+      env: v2env,
+      ctx: stdio,
+    });
+    const body = { name: 'r', username: 'u', password: 'p' };
+    assert.deepEqual(reg.mapCreate(body), body); // identity
+  });
+
+  it('jobs/endpoints stay v1 even under RUNPOD_REST_VERSION=v2', () => {
+    const jobs = resolveBackend({ resource: 'jobs', env: v2env, ctx: stdio });
+    assert.equal(jobs.version, 'v1');
+    assert.equal(jobs.base, 'https://api.runpod.ai/v2'); // serverless, not v2 REST
+    const ep = resolveBackend({
+      resource: 'endpoints',
+      env: v2env,
+      ctx: stdio,
+    });
+    assert.equal(ep.version, 'v1');
+    assert.equal(ep.base, 'https://rest.runpod.io/v1');
   });
 });

--- a/tests/fixtures/v2-create-pod.json
+++ b/tests/fixtures/v2-create-pod.json
@@ -1,0 +1,26 @@
+{
+  "v1Input": {
+    "name": "training-pod",
+    "imageName": "runpod/pytorch:1.0.2",
+    "cloudType": "SECURE",
+    "gpuTypeIds": ["NVIDIA A100", "NVIDIA H100"],
+    "gpuCount": 2,
+    "containerDiskInGb": 20,
+    "volumeInGb": 50,
+    "volumeMountPath": "/workspace",
+    "ports": ["8888/http", "22/tcp"],
+    "env": { "FOO": "bar" },
+    "dataCenterIds": ["US-TX-3", "EU-RO-1"]
+  },
+  "v2Expected": {
+    "image": "runpod/pytorch:1.0.2",
+    "disk": 20,
+    "ports": ["8888/http", "22/tcp"],
+    "env": { "FOO": "bar" },
+    "mounts": { "persistent": { "size": 50, "path": "/workspace" } },
+    "name": "training-pod",
+    "cloud": "SECURE",
+    "dataCenter": "US-TX-3",
+    "gpu": { "id": "NVIDIA A100", "count": 2 }
+  }
+}

--- a/tests/mappers.test.ts
+++ b/tests/mappers.test.ts
@@ -1,0 +1,113 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  mapPodCreateToV2,
+  mapPodUpdateToV2,
+  mapNetworkVolumeCreateToV2,
+  mapTemplateCreateToV2,
+} from '../src/_shared/mappers.js';
+
+const fixture = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL('./fixtures/v2-create-pod.json', import.meta.url)),
+    'utf8'
+  )
+) as { v1Input: Record<string, unknown>; v2Expected: Record<string, unknown> };
+
+describe('mapPodCreateToV2', () => {
+  it('matches the committed fixture (full v1 → v2 body)', () => {
+    assert.deepEqual(mapPodCreateToV2(fixture.v1Input), fixture.v2Expected);
+  });
+
+  it('imageName → image; containerDiskInGb → disk', () => {
+    const out = mapPodCreateToV2({ imageName: 'i', containerDiskInGb: 10 });
+    assert.equal(out.image, 'i');
+    assert.equal(out.disk, 10);
+    assert.equal('imageName' in out, false);
+    assert.equal('containerDiskInGb' in out, false);
+  });
+
+  it('volumeInGb/volumeMountPath → mounts.persistent.{size,path}', () => {
+    const out = mapPodCreateToV2({ volumeInGb: 30, volumeMountPath: '/data' });
+    assert.deepEqual(out.mounts, { persistent: { size: 30, path: '/data' } });
+  });
+
+  it('gpuTypeIds[] → gpu.id (array→scalar) + gpuCount → gpu.count', () => {
+    const out = mapPodCreateToV2({ gpuTypeIds: ['A', 'B'], gpuCount: 4 });
+    assert.deepEqual(out.gpu, { id: 'A', count: 4 });
+  });
+
+  it('cloudType → cloud; dataCenterIds[] → dataCenter (array→scalar)', () => {
+    const out = mapPodCreateToV2({
+      cloudType: 'COMMUNITY',
+      dataCenterIds: ['DC1', 'DC2'],
+    });
+    assert.equal(out.cloud, 'COMMUNITY');
+    assert.equal(out.dataCenter, 'DC1');
+  });
+
+  it('emits gpu only when a gpu field is present (never both gpu+cpu)', () => {
+    const out = mapPodCreateToV2({ name: 'cpu-pod' });
+    assert.equal('gpu' in out, false);
+    assert.equal('cpu' in out, false);
+  });
+
+  it('drops unknown keys and undefined values', () => {
+    const out = mapPodCreateToV2({
+      name: 'p',
+      // @ts-expect-error unknown v1 field
+      bogus: 'x',
+      imageName: undefined,
+    });
+    assert.equal('bogus' in out, false);
+    assert.equal('image' in out, false);
+    assert.deepEqual(out, { name: 'p' });
+  });
+});
+
+describe('mapPodUpdateToV2', () => {
+  it('flattens ContainerConfig, no gpu/cloud/dataCenter', () => {
+    const out = mapPodUpdateToV2({
+      name: 'n',
+      imageName: 'i',
+      volumeInGb: 5,
+      volumeMountPath: '/x',
+    });
+    assert.deepEqual(out, {
+      image: 'i',
+      mounts: { persistent: { size: 5, path: '/x' } },
+      name: 'n',
+    });
+  });
+});
+
+describe('mapNetworkVolumeCreateToV2', () => {
+  it('dataCenterId → dataCenter', () => {
+    const out = mapNetworkVolumeCreateToV2({
+      name: 'v',
+      size: 50,
+      dataCenterId: 'EU-RO-1',
+    });
+    assert.deepEqual(out, { name: 'v', size: 50, dataCenter: 'EU-RO-1' });
+  });
+});
+
+describe('mapTemplateCreateToV2', () => {
+  it('imageName→image, isServerless→serverless, flatten', () => {
+    const out = mapTemplateCreateToV2({
+      name: 't',
+      imageName: 'i',
+      isServerless: true,
+      containerDiskInGb: 10,
+    });
+    assert.deepEqual(out, {
+      image: 'i',
+      disk: 10,
+      name: 't',
+      serverless: true,
+    });
+  });
+});

--- a/tests/mappers.test.ts
+++ b/tests/mappers.test.ts
@@ -30,14 +30,38 @@ describe('mapPodCreateToV2', () => {
     assert.equal('containerDiskInGb' in out, false);
   });
 
-  it('volumeInGb/volumeMountPath → mounts.persistent.{size,path}', () => {
+  it('volumeInGb/volumeMountPath → mounts.persistent.{size,path} (both required)', () => {
     const out = mapPodCreateToV2({ volumeInGb: 30, volumeMountPath: '/data' });
     assert.deepEqual(out.mounts, { persistent: { size: 30, path: '/data' } });
+  });
+
+  it('partial volume (size-only OR path-only) → NO mounts (v2 rejects a partial persistent)', () => {
+    assert.equal('mounts' in mapPodCreateToV2({ volumeInGb: 30 }), false);
+    assert.equal(
+      'mounts' in mapPodCreateToV2({ volumeMountPath: '/data' }),
+      false
+    );
   });
 
   it('gpuTypeIds[] → gpu.id (array→scalar) + gpuCount → gpu.count', () => {
     const out = mapPodCreateToV2({ gpuTypeIds: ['A', 'B'], gpuCount: 4 });
     assert.deepEqual(out.gpu, { id: 'A', count: 4 });
+  });
+
+  it('gpuCount without gpuTypeIds → NO gpu (v2 GpuConfig requires id)', () => {
+    assert.equal('gpu' in mapPodCreateToV2({ gpuCount: 4 }), false);
+  });
+
+  it('empty gpuTypeIds [] → NO gpu', () => {
+    assert.equal('gpu' in mapPodCreateToV2({ gpuTypeIds: [] }), false);
+    assert.equal(
+      'gpu' in mapPodCreateToV2({ gpuTypeIds: [], gpuCount: 2 }),
+      false
+    );
+  });
+
+  it('gpuTypeIds without gpuCount → gpu.id only (count optional, defaults 1 upstream)', () => {
+    assert.deepEqual(mapPodCreateToV2({ gpuTypeIds: ['A'] }).gpu, { id: 'A' });
   });
 
   it('cloudType → cloud; dataCenterIds[] → dataCenter (array→scalar)', () => {
@@ -49,10 +73,9 @@ describe('mapPodCreateToV2', () => {
     assert.equal(out.dataCenter, 'DC1');
   });
 
-  it('emits gpu only when a gpu field is present (never both gpu+cpu)', () => {
-    const out = mapPodCreateToV2({ name: 'cpu-pod' });
+  it('no gpu key when no gpuTypeIds given (translation only — gpu/cpu requirement is enforced by the tool/handler)', () => {
+    const out = mapPodCreateToV2({ name: 'no-gpu' });
     assert.equal('gpu' in out, false);
-    assert.equal('cpu' in out, false);
   });
 
   it('drops unknown keys and undefined values', () => {
@@ -82,6 +105,17 @@ describe('mapPodUpdateToV2', () => {
       name: 'n',
     });
   });
+
+  it('ignores gpu/cloud/dataCenter even when supplied (positive drop proof)', () => {
+    const out = mapPodUpdateToV2({
+      name: 'n',
+      gpuTypeIds: ['A'],
+      gpuCount: 8,
+      cloudType: 'SECURE',
+      dataCenterIds: ['DC1'],
+    });
+    assert.deepEqual(out, { name: 'n' });
+  });
 });
 
 describe('mapNetworkVolumeCreateToV2', () => {
@@ -96,7 +130,7 @@ describe('mapNetworkVolumeCreateToV2', () => {
 });
 
 describe('mapTemplateCreateToV2', () => {
-  it('imageName→image, isServerless→serverless, flatten', () => {
+  it('imageName→image, isServerless→serverless, flatten, category defaults to NVIDIA', () => {
     const out = mapTemplateCreateToV2({
       name: 't',
       imageName: 'i',
@@ -108,6 +142,26 @@ describe('mapTemplateCreateToV2', () => {
       disk: 10,
       name: 't',
       serverless: true,
+      category: 'NVIDIA',
     });
+  });
+
+  it('keeps ports/env and flattens a full volume → mounts.persistent', () => {
+    const out = mapTemplateCreateToV2({
+      name: 't',
+      imageName: 'i',
+      ports: ['8888/http'],
+      env: { K: 'V' },
+      volumeInGb: 20,
+      volumeMountPath: '/data',
+    });
+    assert.deepEqual(out.ports, ['8888/http']);
+    assert.deepEqual(out.env, { K: 'V' });
+    assert.deepEqual(out.mounts, { persistent: { size: 20, path: '/data' } });
+  });
+
+  it('accepts an explicit category override', () => {
+    const out = mapTemplateCreateToV2({ name: 't', category: 'CPU' });
+    assert.equal(out.category, 'CPU');
   });
 });


### PR DESCRIPTION
**Stacked draft — do not merge.** Base = `v2/phase-a4-wire-adapter` (PR #36). Implements **Phase B Steps B1, B2, B3** as a pure, fixture-tested v2 translation layer. Handler wiring (routing through `resolveBackend`) and catalog REST response mapping (B5) are follow-ups.

## Contents
- **`src/_shared/mappers.ts`** — pure v1→v2 request-body mappers:
  - `mapPodCreateToV2`: ContainerConfig flatten (`imageName→image`, `containerDiskInGb→disk`, `volumeInGb/volumeMountPath→mounts.persistent.{size,path}`), `gpuTypeIds[0]→gpu.id` + `gpuCount→gpu.count` (array→scalar), `cloudType→cloud`, `dataCenterIds[0]→dataCenter`, **never emits both `gpu`+`cpu`**, drops unknown/undefined keys.
  - `mapPodUpdateToV2`, `mapTemplateCreateToV2` (`isServerless→serverless`), `mapNetworkVolumeCreateToV2` (`dataCenterId→dataCenter`), registry identity.
- **`resolveBackend` v2 branch**: real v2 paths (`/v2/pods`, `/v2/network-volumes` **hyphen**, `/v2/registries`, `/v2/catalog/*` incl. **non-hyphenated** `datacenters`), version-aware `unwrap`, per-resource `mapCreate`/`mapUpdate`. `jobs`/`endpoints` still pinned v1.
- **`tests/fixtures/v2-create-pod.json`** — committed golden for the full pod-create remap.

## Spec volatility (documented in the mapper header)
Targets the current v2 dev snapshot. Known pending upstream changes that require updating mapper **+ fixture together**: `dataCenter` scalar may revert to `dataCenterIds[]`; `cloud` may drop `ALL`; template `category` may become optional. Per PLAN Part 7/8.

## Tests / checks
- New: `tests/mappers.test.ts` (fixture + field-level cases) + v2 descriptor tests in `backend.test.ts`. **112 pass.** `tsc`/`eslint`/`tsup` clean.

## Scope notes
- This is the v2 **library**; nothing routes to v2 at runtime yet (handlers still use inline v1 paths). The handler routing through `resolveBackend` is the next PR — that's where v2 actually turns on behind the flag.
- `args` collapse for template `dockerEntrypoint/dockerStartCmd` (lossy) deferred per PLAN B3 (needs a join-semantics decision).
- Catalog GraphQL→REST **response** field mapping (B5) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)