### PR TITLE
[Phase B · PR5] Route pod handlers through resolveBackend + B4 actions (v2 keystone)

### DIFF
--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -242,22 +242,25 @@ const CATALOG: ReadonlySet<Resource> = new Set<Resource>([
   'dataCenters',
 ]);
 
-// v2 REST paths (the control-plane resources). Note the renames vs v1:
-// network-volumes (hyphen), registries (was containerregistryauth), catalog/*.
-// Catalog `datacenters` is intentionally NOT hyphenated (matches the spec).
+// v2 REST paths (the control-plane resources). Paths are relative to the v2
+// base which ALREADY includes `/v2` (restV2Base → https://v2-rest.runpod.io/v2),
+// so they do NOT repeat the `/v2` prefix — `base + list` = `.../v2/pods`. (The
+// prober relies on the same convention: `base + /catalog/gpus`.)
+// Renames vs v1: network-volumes (hyphen), registries (was containerregistryauth),
+// catalog/*. Catalog `datacenters` is intentionally NOT hyphenated (matches the spec).
 const V2_REST_PATHS: Partial<
   Record<Resource, { list: string; get?: (id: string) => string }>
 > = {
-  pods: { list: '/v2/pods', get: (id) => `/v2/pods/${id}` },
-  templates: { list: '/v2/templates', get: (id) => `/v2/templates/${id}` },
+  pods: { list: '/pods', get: (id) => `/pods/${id}` },
+  templates: { list: '/templates', get: (id) => `/templates/${id}` },
   networkVolumes: {
-    list: '/v2/network-volumes',
-    get: (id) => `/v2/network-volumes/${id}`,
+    list: '/network-volumes',
+    get: (id) => `/network-volumes/${id}`,
   },
-  registries: { list: '/v2/registries', get: (id) => `/v2/registries/${id}` },
-  gpus: { list: '/v2/catalog/gpus', get: (id) => `/v2/catalog/gpus/${id}` },
-  cpus: { list: '/v2/catalog/cpus' },
-  dataCenters: { list: '/v2/catalog/datacenters' },
+  registries: { list: '/registries', get: (id) => `/registries/${id}` },
+  gpus: { list: '/catalog/gpus', get: (id) => `/catalog/gpus/${id}` },
+  cpus: { list: '/catalog/cpus' },
+  dataCenters: { list: '/catalog/datacenters' },
 };
 
 // v2 request-body mappers per resource (identity where v1==v2, e.g. registries).

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -142,6 +142,16 @@ async function withApiErrorLog<T>(
   }
 }
 
+// The standard MCP tool reply: a single text block holding pretty-printed JSON.
+// Every tool returns this shape, so it lives at module scope.
+function jsonReply(result: unknown) {
+  return {
+    content: [
+      { type: 'text' as const, text: JSON.stringify(result, null, 2) },
+    ],
+  };
+}
+
 function createRunpodRequest(
   apiKey: string,
   tracking: () => Record<string, string>,
@@ -217,18 +227,14 @@ export function registerTools(
     tracking,
     errorPrefix: 'Runpod API Error',
   });
-  const callRestUrl = async (
+  const callRestUrl = (
     url: string,
     method: string = 'GET',
     body?: Record<string, unknown>
-  ): Promise<unknown> => {
-    try {
-      return await restClient(url, method, body);
-    } catch (error) {
-      console.error('Error calling Runpod API:', error);
-      throw error;
-    }
-  };
+  ): Promise<unknown> =>
+    withApiErrorLog('Error calling Runpod API:', () =>
+      restClient(url, method, body)
+    );
   const backendFor = (
     resource: Parameters<typeof resolveBackend>[0]['resource']
   ): Backend =>
@@ -238,9 +244,6 @@ export function registerTools(
       ctx: { transport: ctx.transport },
       v2Available: deps.v2Available,
     });
-  const jsonReply = (result: unknown) => ({
-    content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
-  });
   // B4: pod state transition. v1 has dedicated subpaths (/start, /stop); v2
   // unifies them under POST /pods/{id}/action with an `{action}` body.
   const podAction = async (
@@ -371,14 +374,7 @@ export function registerTools(
         available: isAvailable(gpu),
       }));
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -424,14 +420,7 @@ export function registerTools(
         );
       }
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(dataCenters, null, 2),
-          },
-        ],
-      };
+      return jsonReply(dataCenters);
     }
   );
 
@@ -748,14 +737,7 @@ export function registerTools(
         `/endpoints/${params.endpointId}${queryString}`
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -784,14 +766,7 @@ export function registerTools(
     async (params) => {
       const result = await runpodRequest('/endpoints', 'POST', params);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -827,14 +802,7 @@ export function registerTools(
         updateParams
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -850,14 +818,7 @@ export function registerTools(
         'DELETE'
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -936,14 +897,7 @@ export function registerTools(
         body as Record<string, unknown>
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -978,14 +932,7 @@ export function registerTools(
         body as Record<string, unknown>
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1005,14 +952,7 @@ export function registerTools(
         `/status/${params.jobId}`
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1083,18 +1023,7 @@ export function registerTools(
         await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
       }
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(
-              { ...finalResult, stream: allChunks },
-              null,
-              2
-            ),
-          },
-        ],
-      };
+      return jsonReply({ ...finalResult, stream: allChunks });
     }
   );
 
@@ -1115,14 +1044,7 @@ export function registerTools(
         'POST'
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1143,14 +1065,7 @@ export function registerTools(
         'POST'
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1166,14 +1081,7 @@ export function registerTools(
     async (params) => {
       const result = await serverlessRequest(params.endpointId, '/health');
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1193,14 +1101,7 @@ export function registerTools(
         'POST'
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1256,14 +1157,7 @@ export function registerTools(
     async (params) => {
       const result = await runpodRequest(`/templates/${params.templateId}`);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1304,14 +1198,7 @@ export function registerTools(
     async (params) => {
       const result = await runpodRequest('/templates', 'POST', params);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1340,14 +1227,7 @@ export function registerTools(
         updateParams
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1363,14 +1243,7 @@ export function registerTools(
         'DELETE'
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1399,14 +1272,7 @@ export function registerTools(
         `/networkvolumes/${params.networkVolumeId}`
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1421,14 +1287,7 @@ export function registerTools(
     async (params) => {
       const result = await runpodRequest('/networkvolumes', 'POST', params);
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1453,14 +1312,7 @@ export function registerTools(
         updateParams
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1478,14 +1330,7 @@ export function registerTools(
         'DELETE'
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1518,14 +1363,7 @@ export function registerTools(
         `/containerregistryauth/${params.containerRegistryAuthId}`
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1544,14 +1382,7 @@ export function registerTools(
         params
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
@@ -1569,14 +1400,7 @@ export function registerTools(
         'DELETE'
       );
 
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import { capListResult, listPaginationParams } from './pagination.js';
 import { createHttpClient } from './_shared/http.js';
 import { buildTrackingHeaders } from './_shared/tracking.js';
+import { resolveBackend, type Env, type Backend } from './_shared/backend.js';
 
 // Base URL for Runpod REST API. Override via RUNPOD_REST_API_URL to point at a
 // non-production environment (e.g. when authenticating with a dev API key).
@@ -193,8 +194,10 @@ export function registerTools(
   server: McpServer,
   ctx: ToolContext,
   // Optional test seam: inject a fake fetch to capture outbound requests
-  // offline. Production passes nothing → node-fetch.
-  deps: { fetch?: HttpFetch } = {}
+  // offline. Production passes nothing → node-fetch. `v2Available` is the
+  // already-resolved stdio `auto`-probe verdict (see backend.resolveVersion);
+  // omitted → `auto` resolves to v1.
+  deps: { fetch?: HttpFetch; v2Available?: boolean } = {}
 ): void {
   const tracking = () => trackingHeaders(server, ctx);
   const httpFetch = deps.fetch ?? defaultFetch;
@@ -204,6 +207,55 @@ export function registerTools(
     tracking,
     httpFetch
   );
+
+  // ---- v2-aware REST routing (keystone) ----
+  // A full-URL REST client (the adapter resolves base+path per version) +
+  // helpers to resolve a resource's backend and format the standard JSON reply.
+  const restClient = createHttpClient({
+    apiKey: ctx.apiKey,
+    fetch: httpFetch,
+    tracking,
+    errorPrefix: 'Runpod API Error',
+  });
+  const callRestUrl = async (
+    url: string,
+    method: string = 'GET',
+    body?: Record<string, unknown>
+  ): Promise<unknown> => {
+    try {
+      return await restClient(url, method, body);
+    } catch (error) {
+      console.error('Error calling Runpod API:', error);
+      throw error;
+    }
+  };
+  const backendFor = (
+    resource: Parameters<typeof resolveBackend>[0]['resource']
+  ): Backend =>
+    resolveBackend({
+      resource,
+      env: process.env as Env,
+      ctx: { transport: ctx.transport },
+      v2Available: deps.v2Available,
+    });
+  const jsonReply = (result: unknown) => ({
+    content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+  });
+  // B4: pod state transition. v1 has dedicated subpaths (/start, /stop); v2
+  // unifies them under POST /pods/{id}/action with an `{action}` body.
+  const podAction = async (
+    podId: string,
+    action: 'start' | 'stop'
+  ): Promise<unknown> => {
+    const backend = backendFor('pods');
+    const podPath = backend.get!(podId);
+    if (backend.version === 'v2') {
+      return callRestUrl(`${backend.base}${podPath}/action`, 'POST', {
+        action,
+      });
+    }
+    return callRestUrl(`${backend.base}${podPath}/${action}`, 'POST');
+  };
 
   // ============== INFRASTRUCTURE TOOLS ==============
 
@@ -416,33 +468,44 @@ export function registerTools(
         .describe('Include information about attached network volumes'),
     },
     async (params) => {
-      const queryParams = new URLSearchParams();
+      const backend = backendFor('pods');
 
-      if (params.computeType)
-        queryParams.append('computeType', params.computeType);
-      if (params.gpuTypeId)
-        params.gpuTypeId.forEach((type) =>
-          queryParams.append('gpuTypeId', type)
-        );
-      if (params.dataCenterId)
-        params.dataCenterId.forEach((dc) =>
-          queryParams.append('dataCenterId', dc)
-        );
-      if (params.name) queryParams.append('name', params.name);
-      if (params.includeMachine)
-        queryParams.append('includeMachine', params.includeMachine.toString());
-      if (params.includeNetworkVolume)
-        queryParams.append(
-          'includeNetworkVolume',
-          params.includeNetworkVolume.toString()
-        );
+      // v1 supports query-param filters; v2 has none (the spec declares no query
+      // params and ignores them), so we only build the query string under v1.
+      let queryString = '';
+      if (backend.version === 'v1') {
+        const queryParams = new URLSearchParams();
+        if (params.computeType)
+          queryParams.append('computeType', params.computeType);
+        if (params.gpuTypeId)
+          params.gpuTypeId.forEach((type) =>
+            queryParams.append('gpuTypeId', type)
+          );
+        if (params.dataCenterId)
+          params.dataCenterId.forEach((dc) =>
+            queryParams.append('dataCenterId', dc)
+          );
+        if (params.name) queryParams.append('name', params.name);
+        if (params.includeMachine)
+          queryParams.append(
+            'includeMachine',
+            params.includeMachine.toString()
+          );
+        if (params.includeNetworkVolume)
+          queryParams.append(
+            'includeNetworkVolume',
+            params.includeNetworkVolume.toString()
+          );
+        queryString = queryParams.toString()
+          ? `?${queryParams.toString()}`
+          : '';
+      }
 
-      const queryString = queryParams.toString()
-        ? `?${queryParams.toString()}`
-        : '';
-      const result = await runpodRequest(`/pods${queryString}`);
+      const result = await callRestUrl(
+        `${backend.base}${backend.list}${queryString}`
+      );
 
-      return capListResult(result, {
+      return capListResult(backend.unwrap(result), {
         limit: params.limit,
         cursor: params.cursor,
       });
@@ -464,29 +527,31 @@ export function registerTools(
         .describe('Include information about attached network volumes'),
     },
     async (params) => {
-      const queryParams = new URLSearchParams();
+      const backend = backendFor('pods');
 
-      if (params.includeMachine)
-        queryParams.append('includeMachine', params.includeMachine.toString());
-      if (params.includeNetworkVolume)
-        queryParams.append(
-          'includeNetworkVolume',
-          params.includeNetworkVolume.toString()
-        );
+      // v1-only expansion query params (v2 has no query params on get).
+      let queryString = '';
+      if (backend.version === 'v1') {
+        const queryParams = new URLSearchParams();
+        if (params.includeMachine)
+          queryParams.append(
+            'includeMachine',
+            params.includeMachine.toString()
+          );
+        if (params.includeNetworkVolume)
+          queryParams.append(
+            'includeNetworkVolume',
+            params.includeNetworkVolume.toString()
+          );
+        queryString = queryParams.toString()
+          ? `?${queryParams.toString()}`
+          : '';
+      }
 
-      const queryString = queryParams.toString()
-        ? `?${queryParams.toString()}`
-        : '';
-      const result = await runpodRequest(`/pods/${params.podId}${queryString}`);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.podId)}${queryString}`
+      );
+      return jsonReply(result);
     }
   );
 
@@ -526,16 +591,14 @@ export function registerTools(
         .describe('List of data centers'),
     },
     async (params) => {
-      const result = await runpodRequest('/pods', 'POST', params);
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      const backend = backendFor('pods');
+      const body = backend.mapCreate(params) as Record<string, unknown>;
+      const result = await callRestUrl(
+        `${backend.base}${backend.list}`,
+        'POST',
+        body
+      );
+      return jsonReply(result);
     }
   );
 
@@ -563,60 +626,38 @@ export function registerTools(
     },
     async (params) => {
       const { podId, ...updateParams } = params;
-      const result = await runpodRequest(
-        `/pods/${podId}`,
+      const backend = backendFor('pods');
+      const body = backend.mapUpdate(updateParams) as Record<string, unknown>;
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(podId)}`,
         'PATCH',
-        updateParams
+        body
       );
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      return jsonReply(result);
     }
   );
 
-  // Start Pod
+  // Start Pod — v1: POST /pods/{id}/start ; v2: POST /pods/{id}/action {action:'start'}
   server.tool(
     'start-pod',
     {
       podId: z.string().describe('ID of the pod to start'),
     },
     async (params) => {
-      const result = await runpodRequest(`/pods/${params.podId}/start`, 'POST');
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      const result = await podAction(params.podId, 'start');
+      return jsonReply(result);
     }
   );
 
-  // Stop Pod
+  // Stop Pod — v1: POST /pods/{id}/stop ; v2: POST /pods/{id}/action {action:'stop'}
   server.tool(
     'stop-pod',
     {
       podId: z.string().describe('ID of the pod to stop'),
     },
     async (params) => {
-      const result = await runpodRequest(`/pods/${params.podId}/stop`, 'POST');
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      const result = await podAction(params.podId, 'stop');
+      return jsonReply(result);
     }
   );
 
@@ -627,16 +668,12 @@ export function registerTools(
       podId: z.string().describe('ID of the pod to delete'),
     },
     async (params) => {
-      const result = await runpodRequest(`/pods/${params.podId}`, 'DELETE');
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      const backend = backendFor('pods');
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.podId)}`,
+        'DELETE'
+      );
+      return jsonReply(result);
     }
   );
 

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -495,12 +495,24 @@ describe('resolveBackend (v2 descriptors)', () => {
       assert.equal(b.kind, 'rest', `${resource} kind (catalog is REST in v2)`);
       assert.equal(b.list, list, `${resource} list`);
       assert.equal(get ? b.get!('X') : b.get, get, `${resource} get`);
-      // the combined URL is exactly one /v2 segment
+      // the combined URL is exactly one /v2 segment (list AND get + action)
       assert.equal(
         b.base + b.list,
         `https://v2-rest.runpod.io/v2${list}`,
-        `${resource} combined url`
+        `${resource} combined list url`
       );
+      if (b.get) {
+        assert.equal(
+          b.base + b.get('X'),
+          `https://v2-rest.runpod.io/v2${get}`,
+          `${resource} combined get url`
+        );
+        assert.equal(
+          (b.base + b.get('X') + '/action').includes('/v2/v2'),
+          false,
+          `${resource} action url must not double /v2`
+        );
+      }
     }
   });
 

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -476,15 +476,17 @@ describe('resolveBackend (v2 descriptors)', () => {
   const stdio = { transport: 'stdio' as const };
   const v2env = { RUNPOD_REST_VERSION: 'v2' };
 
-  it('exact v2 paths per resource (renames + catalog)', () => {
+  it('exact v2 paths per resource (relative to /v2 base) + correct COMBINED url', () => {
+    // paths are relative to a base that already includes /v2 — base+list must
+    // NOT double the /v2 (regression guard for the wiring bug).
     const expect: Array<[Resource, string, string | undefined]> = [
-      ['pods', '/v2/pods', '/v2/pods/X'],
-      ['templates', '/v2/templates', '/v2/templates/X'],
-      ['networkVolumes', '/v2/network-volumes', '/v2/network-volumes/X'],
-      ['registries', '/v2/registries', '/v2/registries/X'],
-      ['gpus', '/v2/catalog/gpus', '/v2/catalog/gpus/X'],
-      ['cpus', '/v2/catalog/cpus', undefined],
-      ['dataCenters', '/v2/catalog/datacenters', undefined],
+      ['pods', '/pods', '/pods/X'],
+      ['templates', '/templates', '/templates/X'],
+      ['networkVolumes', '/network-volumes', '/network-volumes/X'],
+      ['registries', '/registries', '/registries/X'],
+      ['gpus', '/catalog/gpus', '/catalog/gpus/X'],
+      ['cpus', '/catalog/cpus', undefined],
+      ['dataCenters', '/catalog/datacenters', undefined],
     ];
     for (const [resource, list, get] of expect) {
       const b = resolveBackend({ resource, env: v2env, ctx: stdio });
@@ -493,6 +495,12 @@ describe('resolveBackend (v2 descriptors)', () => {
       assert.equal(b.kind, 'rest', `${resource} kind (catalog is REST in v2)`);
       assert.equal(b.list, list, `${resource} list`);
       assert.equal(get ? b.get!('X') : b.get, get, `${resource} get`);
+      // the combined URL is exactly one /v2 segment
+      assert.equal(
+        b.base + b.list,
+        `https://v2-rest.runpod.io/v2${list}`,
+        `${resource} combined url`
+      );
     }
   });
 
@@ -538,7 +546,8 @@ describe('resolveBackend (v2 descriptors)', () => {
     const pods = resolveBackend({ resource: 'pods', env, ctx: stdio });
     assert.equal(pods.version, 'v2');
     assert.equal(pods.base, 'https://v2-rest.runpod.io/v2');
-    assert.equal(pods.list, '/v2/pods');
+    assert.equal(pods.list, '/pods');
+    assert.equal(pods.base + pods.list, 'https://v2-rest.runpod.io/v2/pods');
     assert.equal(
       (pods.mapCreate({ imageName: 'i' }) as Record<string, unknown>).image,
       'i'

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -253,6 +253,109 @@ describe('outbound-request golden (v1 unchanged)', () => {
   });
 });
 
+describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
+  // backendFor reads process.env at handler-call time, so set/restore around each.
+  function withV2<T>(fn: () => T): T {
+    const prev = process.env.RUNPOD_REST_VERSION;
+    process.env.RUNPOD_REST_VERSION = 'v2';
+    try {
+      return fn();
+    } finally {
+      if (prev === undefined) delete process.env.RUNPOD_REST_VERSION;
+      else process.env.RUNPOD_REST_VERSION = prev;
+    }
+  }
+
+  it('list-pods → GET <v2base>/v2/pods (single /v2, no filter query)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { pods: [] } });
+      await handlers.get('list-pods')!({ computeType: 'GPU', name: 'x' });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods');
+      assert.equal(outbound[0].method, 'GET');
+    });
+  });
+
+  it('list-pods unwraps the v2 {pods:[…]} envelope before capping', async () => {
+    await withV2(async () => {
+      const items = Array.from({ length: 25 }, (_, i) => ({ id: i }));
+      const { handlers } = harness({ jsonBody: { pods: items } });
+      const out = await handlers.get('list-pods')!({});
+      const env = JSON.parse(
+        (out as { content: Array<{ text: string }> }).content[0].text
+      );
+      assert.equal(env.pagination.total, 25);
+      assert.equal(env.items.length, 20);
+    });
+  });
+
+  it('create-pod → POST <v2base>/v2/pods with the v2-mapped body', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('create-pod')!({
+        name: 'p',
+        imageName: 'img:1',
+        gpuTypeIds: ['A100', 'H100'],
+        gpuCount: 2,
+        dataCenterIds: ['US-TX-3'],
+      });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods');
+      assert.equal(outbound[0].method, 'POST');
+      const body = JSON.parse(outbound[0].body!);
+      assert.equal(body.image, 'img:1');
+      assert.equal('imageName' in body, false);
+      assert.deepEqual(body.gpu, { id: 'A100', count: 2 });
+      assert.equal(body.dataCenter, 'US-TX-3');
+    });
+  });
+
+  it('stop-pod → POST <v2base>/v2/pods/{id}/action {action:"stop"} (B4)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('stop-pod')!({ podId: 'pod_9' });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/pods/pod_9/action'
+      );
+      assert.equal(outbound[0].method, 'POST');
+      assert.deepEqual(JSON.parse(outbound[0].body!), { action: 'stop' });
+    });
+  });
+
+  it('start-pod → POST .../v2/pods/{id}/action {action:"start"} (B4)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('start-pod')!({ podId: 'pod_1' });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/pods/pod_1/action'
+      );
+      assert.deepEqual(JSON.parse(outbound[0].body!), { action: 'start' });
+    });
+  });
+
+  it('update-pod → PATCH .../v2/pods/{id} with mapped body (no podId)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('update-pod')!({ podId: 'pod_2', imageName: 'i2' });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods/pod_2');
+      assert.equal(outbound[0].method, 'PATCH');
+      const body = JSON.parse(outbound[0].body!);
+      assert.equal(body.image, 'i2');
+      assert.equal('podId' in body, false);
+      assert.equal('imageName' in body, false);
+    });
+  });
+
+  it('delete-pod → DELETE .../v2/pods/{id}', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('delete-pod')!({ podId: 'pod_x' });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods/pod_x');
+      assert.equal(outbound[0].method, 'DELETE');
+    });
+  });
+});
+
 describe('stream-job poll loop (sequenced responses)', () => {
   it('polls /v2/{id}/stream/{jobId} until a terminal status', async () => {
     const { handlers, outbound } = harness({

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -255,11 +255,13 @@ describe('outbound-request golden (v1 unchanged)', () => {
 
 describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
   // backendFor reads process.env at handler-call time, so set/restore around each.
-  function withV2<T>(fn: () => T): T {
+  // MUST await the body inside try/finally — otherwise finally restores the env
+  // before the awaited handler runs (the body would then read the wrong version).
+  async function withV2<T>(fn: () => Promise<T>): Promise<T> {
     const prev = process.env.RUNPOD_REST_VERSION;
     process.env.RUNPOD_REST_VERSION = 'v2';
     try {
-      return fn();
+      return await fn();
     } finally {
       if (prev === undefined) delete process.env.RUNPOD_REST_VERSION;
       else process.env.RUNPOD_REST_VERSION = prev;
@@ -288,6 +290,19 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
     });
   });
 
+  it('get-pod → GET <v2base>/v2/pods/{id} with NO query (v1-only filters dropped)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('get-pod')!({
+        podId: 'pod_7',
+        includeMachine: true,
+        includeNetworkVolume: true,
+      });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods/pod_7');
+      assert.equal(outbound[0].method, 'GET');
+    });
+  });
+
   it('create-pod → POST <v2base>/v2/pods with the v2-mapped body', async () => {
     await withV2(async () => {
       const { handlers, outbound } = harness({ jsonBody: {} });
@@ -297,6 +312,8 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
         gpuTypeIds: ['A100', 'H100'],
         gpuCount: 2,
         dataCenterIds: ['US-TX-3'],
+        volumeInGb: 40,
+        volumeMountPath: '/workspace',
       });
       assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods');
       assert.equal(outbound[0].method, 'POST');
@@ -305,7 +322,33 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
       assert.equal('imageName' in body, false);
       assert.deepEqual(body.gpu, { id: 'A100', count: 2 });
       assert.equal(body.dataCenter, 'US-TX-3');
+      assert.deepEqual(body.mounts, {
+        persistent: { size: 40, path: '/workspace' },
+      });
     });
+  });
+
+  it('create-pod v2 with a partial volume drops mounts (no size-only mount)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('create-pod')!({ imageName: 'i', volumeInGb: 40 });
+      const body = JSON.parse(outbound[0].body!);
+      assert.equal('mounts' in body, false);
+    });
+  });
+
+  it('per-resource override (RUNPOD_REST_VERSION_PODS=v2) routes a handler to v2 end-to-end', () => {
+    const prev = process.env.RUNPOD_REST_VERSION_PODS;
+    process.env.RUNPOD_REST_VERSION_PODS = 'v2';
+    try {
+      const { handlers, outbound } = harness({ jsonBody: { pods: [] } });
+      return handlers.get('list-pods')!({}).then(() => {
+        assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods');
+      });
+    } finally {
+      if (prev === undefined) delete process.env.RUNPOD_REST_VERSION_PODS;
+      else process.env.RUNPOD_REST_VERSION_PODS = prev;
+    }
   });
 
   it('stop-pod → POST <v2base>/v2/pods/{id}/action {action:"stop"} (B4)', async () => {

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1,5 +1,13 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+
+// Defense-in-depth: the v1 goldens assume the version env vars are unset. Clear
+// them before every test so a leak (from another test or the CI env) can't
+// silently flip v1 goldens to v2.
+beforeEach(() => {
+  delete process.env.RUNPOD_REST_VERSION;
+  delete process.env.RUNPOD_REST_VERSION_PODS;
+});
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerTools } from '../src/tools.js';


### PR DESCRIPTION
**Stacked draft — do not merge.** Base = `v2/phase-b1-mappers-descriptors` (PR #37). The **keystone** — pods actually route to v2 behind the flag. Implements **B4** + the handler-routing pattern.

## What changed
- **Descriptor convention bug fixed** (surfaced by wiring): v2 base ends in `/v2` and v2 paths were *also* `/v2/pods` → `base+path` doubled to `/v2/v2/pods`. v2 paths are now **bare** (`/pods`, `/catalog/gpus`, …) so `base+path` = exactly one `/v2`. Matches what the prober already assumed. Added a combined-URL regression test.
- **`registerTools` gains** `deps.v2Available` + `callRestUrl` (full-URL REST client), `backendFor()`, `jsonReply()`, and `podAction()` (B4).
- **All 7 pod handlers routed through `resolveBackend`:**
  - **v1: byte-identical** — filters, paths, bodies, query encoding all preserved.
  - **v2:** `/v2/*` paths, `mapCreate`/`mapUpdate` bodies, `unwrap`+cap lists, and **`POST /v2/pods/{id}/action {action}`** for start/stop (B4). v2 drops the v1-only list/get filter query params (spec declares none).

## Golden coverage (both versions)
- v1 (unchanged): list (+filters), get, create (byte-identical body), update (id-strip), start/stop (`/start`,`/stop`), delete.
- v2: list (`/v2/pods`, no filters, envelope unwrap + cap), create (mapped body — `image`/`gpu`/`dataCenter`), update (mapped, no podId), **start/stop → `/action` with `{action}`**, delete. Asserts the single-`/v2` combined URL.

## Checks
**127 tests pass** · `tsc`/`eslint`/`tsup` clean.

## Scope
Pods only. templates/volumes/registries routing + catalog B5 (GraphQL→REST) + C1/C2/C3 follow in subsequent stacked PRs, using this exact pattern. The stdio entrypoint awaiting `createV2Prober()` to supply `deps.v2Available` for `auto` mode is a small follow-up (explicit `RUNPOD_REST_VERSION=v2` works today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)