### PR TITLE
[Phase B · PR6] Route template/volume/registry handlers through resolveBackend

### DIFF
--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -12,6 +12,7 @@ import {
   mapPodCreateToV2,
   mapPodUpdateToV2,
   mapTemplateCreateToV2,
+  mapTemplateUpdateToV2,
   mapNetworkVolumeCreateToV2,
 } from './mappers.js';
 
@@ -282,7 +283,8 @@ const V2_MAPPERS: Partial<
   templates: {
     create: (b) =>
       mapTemplateCreateToV2(b as Parameters<typeof mapTemplateCreateToV2>[0]),
-    update: identity,
+    update: (b) =>
+      mapTemplateUpdateToV2(b as Parameters<typeof mapTemplateUpdateToV2>[0]),
   },
   networkVolumes: {
     create: (b) =>

--- a/src/_shared/mappers.ts
+++ b/src/_shared/mappers.ts
@@ -149,6 +149,25 @@ export function mapTemplateCreateToV2(
   };
 }
 
+interface V1TemplateUpdate {
+  name?: string;
+  imageName?: string;
+  ports?: string[];
+  env?: Record<string, string>;
+  // readme has no v2 equivalent — dropped.
+}
+// Update has no required `category`; just flatten ContainerConfig + name. Crucial:
+// this maps imageName→image (an identity mapper would wrongly send `imageName` to
+// v2, which expects `image`).
+export function mapTemplateUpdateToV2(
+  params: V1TemplateUpdate
+): Record<string, unknown> {
+  return {
+    ...containerConfigToV2(params),
+    ...compact({ name: params.name }),
+  };
+}
+
 // Registry create is unchanged between v1 and v2 (name/username/password) →
 // identity. Exposed for symmetry so the descriptor table is uniform.
 export function identityMapper(body: unknown): unknown {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1129,19 +1129,23 @@ export function registerTools(
         ),
     },
     async (params) => {
-      const queryParams = new URLSearchParams();
-      if (params.includeRunpodTemplates)
-        queryParams.set('includeRunpodTemplates', 'true');
-      if (params.includePublicTemplates)
-        queryParams.set('includePublicTemplates', 'true');
-      if (params.includeEndpointBoundTemplates)
-        queryParams.set('includeEndpointBoundTemplates', 'true');
-      const query = queryParams.toString();
-      const result = await runpodRequest(
-        `/templates${query ? `?${query}` : ''}`
+      const backend = backendFor('templates');
+      let query = '';
+      if (backend.version === 'v1') {
+        const queryParams = new URLSearchParams();
+        if (params.includeRunpodTemplates)
+          queryParams.set('includeRunpodTemplates', 'true');
+        if (params.includePublicTemplates)
+          queryParams.set('includePublicTemplates', 'true');
+        if (params.includeEndpointBoundTemplates)
+          queryParams.set('includeEndpointBoundTemplates', 'true');
+        query = queryParams.toString() ? `?${queryParams.toString()}` : '';
+      }
+      const result = await callRestUrl(
+        `${backend.base}${backend.list}${query}`
       );
 
-      return capListResult(result, {
+      return capListResult(backend.unwrap(result), {
         limit: params.limit,
         cursor: params.cursor,
       });
@@ -1155,8 +1159,10 @@ export function registerTools(
       templateId: z.string().describe('ID of the template to retrieve'),
     },
     async (params) => {
-      const result = await runpodRequest(`/templates/${params.templateId}`);
-
+      const backend = backendFor('templates');
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.templateId)}`
+      );
       return jsonReply(result);
     }
   );
@@ -1196,8 +1202,13 @@ export function registerTools(
         .describe('README content in markdown format'),
     },
     async (params) => {
-      const result = await runpodRequest('/templates', 'POST', params);
-
+      const backend = backendFor('templates');
+      const body = backend.mapCreate(params) as Record<string, unknown>;
+      const result = await callRestUrl(
+        `${backend.base}${backend.list}`,
+        'POST',
+        body
+      );
       return jsonReply(result);
     }
   );
@@ -1221,12 +1232,13 @@ export function registerTools(
     },
     async (params) => {
       const { templateId, ...updateParams } = params;
-      const result = await runpodRequest(
-        `/templates/${templateId}`,
+      const backend = backendFor('templates');
+      const body = backend.mapUpdate(updateParams) as Record<string, unknown>;
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(templateId)}`,
         'PATCH',
-        updateParams
+        body
       );
-
       return jsonReply(result);
     }
   );
@@ -1238,11 +1250,11 @@ export function registerTools(
       templateId: z.string().describe('ID of the template to delete'),
     },
     async (params) => {
-      const result = await runpodRequest(
-        `/templates/${params.templateId}`,
+      const backend = backendFor('templates');
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.templateId)}`,
         'DELETE'
       );
-
       return jsonReply(result);
     }
   );
@@ -1251,9 +1263,10 @@ export function registerTools(
 
   // List Network Volumes
   server.tool('list-network-volumes', listPaginationParams, async (params) => {
-    const result = await runpodRequest('/networkvolumes');
+    const backend = backendFor('networkVolumes');
+    const result = await callRestUrl(`${backend.base}${backend.list}`);
 
-    return capListResult(result, {
+    return capListResult(backend.unwrap(result), {
       limit: params.limit,
       cursor: params.cursor,
     });
@@ -1268,10 +1281,10 @@ export function registerTools(
         .describe('ID of the network volume to retrieve'),
     },
     async (params) => {
-      const result = await runpodRequest(
-        `/networkvolumes/${params.networkVolumeId}`
+      const backend = backendFor('networkVolumes');
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.networkVolumeId)}`
       );
-
       return jsonReply(result);
     }
   );
@@ -1285,8 +1298,13 @@ export function registerTools(
       dataCenterId: z.string().describe('Data center ID'),
     },
     async (params) => {
-      const result = await runpodRequest('/networkvolumes', 'POST', params);
-
+      const backend = backendFor('networkVolumes');
+      const body = backend.mapCreate(params) as Record<string, unknown>;
+      const result = await callRestUrl(
+        `${backend.base}${backend.list}`,
+        'POST',
+        body
+      );
       return jsonReply(result);
     }
   );
@@ -1306,12 +1324,13 @@ export function registerTools(
     },
     async (params) => {
       const { networkVolumeId, ...updateParams } = params;
-      const result = await runpodRequest(
-        `/networkvolumes/${networkVolumeId}`,
+      const backend = backendFor('networkVolumes');
+      const body = backend.mapUpdate(updateParams) as Record<string, unknown>;
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(networkVolumeId)}`,
         'PATCH',
-        updateParams
+        body
       );
-
       return jsonReply(result);
     }
   );
@@ -1325,11 +1344,11 @@ export function registerTools(
         .describe('ID of the network volume to delete'),
     },
     async (params) => {
-      const result = await runpodRequest(
-        `/networkvolumes/${params.networkVolumeId}`,
+      const backend = backendFor('networkVolumes');
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.networkVolumeId)}`,
         'DELETE'
       );
-
       return jsonReply(result);
     }
   );
@@ -1341,9 +1360,10 @@ export function registerTools(
     'list-container-registry-auths',
     listPaginationParams,
     async (params) => {
-      const result = await runpodRequest('/containerregistryauth');
+      const backend = backendFor('registries');
+      const result = await callRestUrl(`${backend.base}${backend.list}`);
 
-      return capListResult(result, {
+      return capListResult(backend.unwrap(result), {
         limit: params.limit,
         cursor: params.cursor,
       });
@@ -1359,10 +1379,10 @@ export function registerTools(
         .describe('ID of the container registry auth to retrieve'),
     },
     async (params) => {
-      const result = await runpodRequest(
-        `/containerregistryauth/${params.containerRegistryAuthId}`
+      const backend = backendFor('registries');
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.containerRegistryAuthId)}`
       );
-
       return jsonReply(result);
     }
   );
@@ -1376,12 +1396,13 @@ export function registerTools(
       password: z.string().describe('Registry password'),
     },
     async (params) => {
-      const result = await runpodRequest(
-        '/containerregistryauth',
+      const backend = backendFor('registries');
+      const body = backend.mapCreate(params) as Record<string, unknown>;
+      const result = await callRestUrl(
+        `${backend.base}${backend.list}`,
         'POST',
-        params
+        body
       );
-
       return jsonReply(result);
     }
   );
@@ -1395,11 +1416,11 @@ export function registerTools(
         .describe('ID of the container registry auth to delete'),
     },
     async (params) => {
-      const result = await runpodRequest(
-        `/containerregistryauth/${params.containerRegistryAuthId}`,
+      const backend = backendFor('registries');
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.containerRegistryAuthId)}`,
         'DELETE'
       );
-
       return jsonReply(result);
     }
   );

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -261,21 +261,21 @@ describe('outbound-request golden (v1 unchanged)', () => {
   });
 });
 
-describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
-  // backendFor reads process.env at handler-call time, so set/restore around each.
-  // MUST await the body inside try/finally — otherwise finally restores the env
-  // before the awaited handler runs (the body would then read the wrong version).
-  async function withV2<T>(fn: () => Promise<T>): Promise<T> {
-    const prev = process.env.RUNPOD_REST_VERSION;
-    process.env.RUNPOD_REST_VERSION = 'v2';
-    try {
-      return await fn();
-    } finally {
-      if (prev === undefined) delete process.env.RUNPOD_REST_VERSION;
-      else process.env.RUNPOD_REST_VERSION = prev;
-    }
+// backendFor reads process.env at handler-call time, so set/restore around each.
+// MUST await the body inside try/finally — otherwise finally restores the env
+// before the awaited handler runs (the body would then read the wrong version).
+async function withV2<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.RUNPOD_REST_VERSION;
+  process.env.RUNPOD_REST_VERSION = 'v2';
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.RUNPOD_REST_VERSION;
+    else process.env.RUNPOD_REST_VERSION = prev;
   }
+}
 
+describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
   it('list-pods → GET <v2base>/v2/pods (single /v2, no filter query)', async () => {
     await withV2(async () => {
       const { handlers, outbound } = harness({ jsonBody: { pods: [] } });
@@ -402,6 +402,107 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
       const { handlers, outbound } = harness({ jsonBody: {} });
       await handlers.get('delete-pod')!({ podId: 'pod_x' });
       assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/pods/pod_x');
+      assert.equal(outbound[0].method, 'DELETE');
+    });
+  });
+});
+
+describe('template / network-volume / registry routing under v2', () => {
+  it('list-templates → GET .../v2/templates (no v1 include* query)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { templates: [] } });
+      await handlers.get('list-templates')!({ includeRunpodTemplates: true });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/templates');
+    });
+  });
+
+  it('create-template → POST .../v2/templates with mapped body (serverless + category)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('create-template')!({
+        name: 't',
+        imageName: 'i',
+        isServerless: true,
+      });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/templates');
+      const body = JSON.parse(outbound[0].body!);
+      assert.equal(body.image, 'i');
+      assert.equal('imageName' in body, false);
+      assert.equal(body.serverless, true);
+      assert.equal(body.category, 'NVIDIA');
+    });
+  });
+
+  it('list-network-volumes → GET .../v2/network-volumes (hyphen)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({
+        jsonBody: { networkVolumes: [] },
+      });
+      await handlers.get('list-network-volumes')!({});
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/network-volumes'
+      );
+    });
+  });
+
+  it('create-network-volume → POST .../v2/network-volumes, dataCenterId→dataCenter', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('create-network-volume')!({
+        name: 'v',
+        size: 50,
+        dataCenterId: 'EU-RO-1',
+      });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/network-volumes'
+      );
+      const body = JSON.parse(outbound[0].body!);
+      assert.equal(body.dataCenter, 'EU-RO-1');
+      assert.equal('dataCenterId' in body, false);
+    });
+  });
+
+  it('get-network-volume → GET .../v2/network-volumes/{id}', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('get-network-volume')!({ networkVolumeId: 'nv_1' });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/network-volumes/nv_1'
+      );
+    });
+  });
+
+  it('list-container-registry-auths → GET .../v2/registries (rename)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { registries: [] } });
+      await handlers.get('list-container-registry-auths')!({});
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/registries');
+    });
+  });
+
+  it('create-container-registry-auth → POST .../v2/registries (identity body)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      const params = { name: 'r', username: 'u', password: 'p' };
+      await handlers.get('create-container-registry-auth')!({ ...params });
+      assert.equal(outbound[0].url, 'https://v2-rest.runpod.io/v2/registries');
+      assert.deepEqual(JSON.parse(outbound[0].body!), params);
+    });
+  });
+
+  it('delete-container-registry-auth → DELETE .../v2/registries/{id}', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('delete-container-registry-auth')!({
+        containerRegistryAuthId: 'cra_1',
+      });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/registries/cra_1'
+      );
       assert.equal(outbound[0].method, 'DELETE');
     });
   });

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -5,8 +5,15 @@ import assert from 'node:assert/strict';
 // them before every test so a leak (from another test or the CI env) can't
 // silently flip v1 goldens to v2.
 beforeEach(() => {
-  delete process.env.RUNPOD_REST_VERSION;
-  delete process.env.RUNPOD_REST_VERSION_PODS;
+  for (const k of [
+    'RUNPOD_REST_VERSION',
+    'RUNPOD_REST_VERSION_PODS',
+    'RUNPOD_REST_VERSION_TEMPLATES',
+    'RUNPOD_REST_VERSION_NETWORK_VOLUMES',
+    'RUNPOD_REST_VERSION_REGISTRIES',
+  ]) {
+    delete process.env[k];
+  }
 });
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -204,6 +211,103 @@ describe('outbound-request golden (v1 unchanged)', () => {
     assert.equal(outbound[0].url, 'https://rest.runpod.io/v1/templates');
     assert.equal(outbound[0].method, 'POST');
     assert.equal(outbound[0].body, JSON.stringify(params));
+  });
+
+  // --- v1 wire-locks for the rerouted handlers (silent-regression guard) ---
+  it('list-templates forwards v1 include* query params', async () => {
+    const { handlers, outbound } = harness({ jsonBody: [] });
+    await handlers.get('list-templates')!({
+      includeRunpodTemplates: true,
+      includePublicTemplates: true,
+    });
+    assert.equal(
+      outbound[0].url,
+      'https://rest.runpod.io/v1/templates?includeRunpodTemplates=true&includePublicTemplates=true'
+    );
+  });
+
+  it('get-template → GET <rest>/v1/templates/{id}', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    await handlers.get('get-template')!({ templateId: 't_1' });
+    assert.equal(outbound[0].url, 'https://rest.runpod.io/v1/templates/t_1');
+    assert.equal(outbound[0].method, 'GET');
+    assert.equal(outbound[0].body, undefined);
+  });
+
+  it('update-template → PATCH <rest>/v1/templates/{id}, body excludes templateId, imageName preserved', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    await handlers.get('update-template')!({
+      templateId: 't_1',
+      imageName: 'img2',
+    });
+    assert.equal(outbound[0].url, 'https://rest.runpod.io/v1/templates/t_1');
+    assert.equal(outbound[0].method, 'PATCH');
+    const body = JSON.parse(outbound[0].body!);
+    assert.equal('templateId' in body, false);
+    assert.equal(body.imageName, 'img2'); // v1 identity keeps imageName
+  });
+
+  it('delete-template → DELETE <rest>/v1/templates/{id}', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    await handlers.get('delete-template')!({ templateId: 't_1' });
+    assert.equal(outbound[0].url, 'https://rest.runpod.io/v1/templates/t_1');
+    assert.equal(outbound[0].method, 'DELETE');
+  });
+
+  it('get-network-volume → GET <rest>/v1/networkvolumes/{id}', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    await handlers.get('get-network-volume')!({ networkVolumeId: 'nv_1' });
+    assert.equal(
+      outbound[0].url,
+      'https://rest.runpod.io/v1/networkvolumes/nv_1'
+    );
+    assert.equal(outbound[0].method, 'GET');
+  });
+
+  it('delete-network-volume → DELETE <rest>/v1/networkvolumes/{id}', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    await handlers.get('delete-network-volume')!({ networkVolumeId: 'nv_1' });
+    assert.equal(
+      outbound[0].url,
+      'https://rest.runpod.io/v1/networkvolumes/nv_1'
+    );
+    assert.equal(outbound[0].method, 'DELETE');
+  });
+
+  it('get-container-registry-auth → GET <rest>/v1/containerregistryauth/{id}', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    await handlers.get('get-container-registry-auth')!({
+      containerRegistryAuthId: 'cra_1',
+    });
+    assert.equal(
+      outbound[0].url,
+      'https://rest.runpod.io/v1/containerregistryauth/cra_1'
+    );
+    assert.equal(outbound[0].method, 'GET');
+  });
+
+  it('create-container-registry-auth → POST <rest>/v1/containerregistryauth, body byte-identical', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    const params = { name: 'r', username: 'u', password: 'p' };
+    await handlers.get('create-container-registry-auth')!({ ...params });
+    assert.equal(
+      outbound[0].url,
+      'https://rest.runpod.io/v1/containerregistryauth'
+    );
+    assert.equal(outbound[0].method, 'POST');
+    assert.equal(outbound[0].body, JSON.stringify(params));
+  });
+
+  it('delete-container-registry-auth → DELETE <rest>/v1/containerregistryauth/{id}', async () => {
+    const { handlers, outbound } = harness({ jsonBody: {} });
+    await handlers.get('delete-container-registry-auth')!({
+      containerRegistryAuthId: 'cra_1',
+    });
+    assert.equal(
+      outbound[0].url,
+      'https://rest.runpod.io/v1/containerregistryauth/cra_1'
+    );
+    assert.equal(outbound[0].method, 'DELETE');
   });
 
   it('create-network-volume → POST <rest>/v1/networkvolumes, body byte-identical', async () => {
@@ -472,6 +576,41 @@ describe('template / network-volume / registry routing under v2', () => {
         outbound[0].url,
         'https://v2-rest.runpod.io/v2/network-volumes/nv_1'
       );
+    });
+  });
+
+  it('update-template → PATCH .../v2/templates/{id}, imageName→image (NOT identity), no templateId', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('update-template')!({
+        templateId: 't_1',
+        imageName: 'img2',
+      });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/templates/t_1'
+      );
+      assert.equal(outbound[0].method, 'PATCH');
+      const body = JSON.parse(outbound[0].body!);
+      assert.equal(body.image, 'img2'); // v2 mapper maps it
+      assert.equal('imageName' in body, false);
+      assert.equal('templateId' in body, false);
+    });
+  });
+
+  it('update-network-volume → PATCH .../v2/network-volumes/{id}, body excludes id', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('update-network-volume')!({
+        networkVolumeId: 'nv_1',
+        size: 100,
+      });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/network-volumes/nv_1'
+      );
+      assert.equal(outbound[0].method, 'PATCH');
+      assert.equal('networkVolumeId' in JSON.parse(outbound[0].body!), false);
     });
   });
 

--- a/tests/mappers.test.ts
+++ b/tests/mappers.test.ts
@@ -8,6 +8,7 @@ import {
   mapPodUpdateToV2,
   mapNetworkVolumeCreateToV2,
   mapTemplateCreateToV2,
+  mapTemplateUpdateToV2,
 } from '../src/_shared/mappers.js';
 
 const fixture = JSON.parse(
@@ -163,5 +164,14 @@ describe('mapTemplateCreateToV2', () => {
   it('accepts an explicit category override', () => {
     const out = mapTemplateCreateToV2({ name: 't', category: 'CPU' });
     assert.equal(out.category, 'CPU');
+  });
+});
+
+describe('mapTemplateUpdateToV2', () => {
+  it('maps imageName→image (not identity), keeps name, no category forced', () => {
+    const out = mapTemplateUpdateToV2({ name: 'n', imageName: 'i' });
+    assert.deepEqual(out, { image: 'i', name: 'n' });
+    assert.equal('imageName' in out, false);
+    assert.equal('category' in out, false);
   });
 });


### PR DESCRIPTION
**Stacked draft — do not merge.** Base = `v2/phase-b4-pods-routing` (PR #38). Applies the proven pod-routing pattern to the remaining control-plane CRUD resources (14 handlers).

## Changes
All template / network-volume / registry handlers now route through `resolveBackend` + `callRestUrl`:
- **v1: byte-identical** — paths (`/templates`, `/networkvolumes`, `/containerregistryauth`), bodies, id-strip, and the template `include*` query all preserved.
- **v2:** `/v2/templates`, `/v2/network-volumes` (hyphen), `/v2/registries` (rename); `mapCreate`/`mapUpdate` bodies (`serverless`+`category:NVIDIA`, `dataCenterId→dataCenter`, registry identity); list responses `unwrap`+capped; v1-only template filters dropped on v2.
- **Unchanged:** endpoints CRUD + serverless job tools stay on `runpodRequest`/`serverlessRequest` (v1-pinned — no v2 home).

## Golden coverage
- v1 (pre-existing, still green): create-template, create/update/list network-volume, list registries.
- v2 (new): list-templates (no include* query), create-template (mapped body), list/create/get network-volume (hyphen + dataCenter rename), list/create/delete registries (rename + identity).

## Checks
**138 tests pass** · `tsc`/`eslint`/`tsup` clean.

## Remaining after this
B5 (catalog GraphQL→REST + response mappers), C1 (restart / list-cpu-types / get-gpu-type), C2 (501→clean message), C3 (probe wiring + flip default), B6 (live CRUD smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)