### PR TITLE
[Phase B/C · PR8] Catalog GraphQL→REST under v2 + list-cpu-types/get-gpu-type (B5/C1)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -292,6 +292,34 @@ export function registerTools(
         ),
     },
     async (params) => {
+      const backend = backendFor('gpus');
+      if (backend.version === 'v2') {
+        // v2 REST: GET /v2/catalog/gpus → { gpus: [...] }. Filters re-applied
+        // against v2 field names (memory/secure/community/name). v2 has no
+        // realtime stockStatus, so `includeUnavailable` is a documented no-op.
+        const raw = await callRestUrl(`${backend.base}${backend.list}`);
+        let gpus = backend.unwrap(raw) as Array<Record<string, unknown>>;
+        if (params.minMemoryGb !== undefined)
+          gpus = gpus.filter(
+            (g) => Number(g.memory ?? 0) >= params.minMemoryGb!
+          );
+        if (params.secureCloudOnly) gpus = gpus.filter((g) => g.secure);
+        if (params.communityCloudOnly) gpus = gpus.filter((g) => g.community);
+        if (params.searchTerm) {
+          const t = params.searchTerm.toLowerCase();
+          gpus = gpus.filter(
+            (g) =>
+              String(g.id ?? '')
+                .toLowerCase()
+                .includes(t) ||
+              String(g.name ?? '')
+                .toLowerCase()
+                .includes(t)
+          );
+        }
+        return jsonReply(gpus);
+      }
+
       interface GpuTypesResponse {
         gpuTypes: Array<{
           id: string;
@@ -390,6 +418,23 @@ export function registerTools(
         ),
     },
     async (params) => {
+      const backend = backendFor('dataCenters');
+      if (backend.version === 'v2') {
+        // v2 REST: GET /v2/catalog/datacenters → { dataCenters: [...] }. v2 uses
+        // a `region` enum (vs v1 free-text `location`); region filter matches it.
+        const raw = await callRestUrl(`${backend.base}${backend.list}`);
+        let dcs = backend.unwrap(raw) as Array<Record<string, unknown>>;
+        if (params.region) {
+          const t = params.region.toLowerCase();
+          dcs = dcs.filter((dc) =>
+            String(dc.region ?? '')
+              .toLowerCase()
+              .includes(t)
+          );
+        }
+        return jsonReply(dcs);
+      }
+
       interface DataCentersResponse {
         dataCenters: Array<{
           id: string;
@@ -421,6 +466,42 @@ export function registerTools(
       }
 
       return jsonReply(dataCenters);
+    }
+  );
+
+  // List CPU Types (v2-only — v2 catalog REST has no v1/GraphQL equivalent)
+  server.tool('list-cpu-types', {}, async () => {
+    const backend = backendFor('cpus');
+    if (backend.version === 'v1') {
+      return jsonReply({
+        error:
+          'list-cpu-types is only available on the v2 REST API. Set RUNPOD_REST_VERSION=v2.',
+        status: 501,
+      });
+    }
+    const raw = await callRestUrl(`${backend.base}${backend.list}`);
+    return jsonReply(backend.unwrap(raw));
+  });
+
+  // Get GPU Type by id (v2-only — GET /v2/catalog/gpus/{id})
+  server.tool(
+    'get-gpu-type',
+    {
+      gpuTypeId: z.string().describe('ID of the GPU type to retrieve'),
+    },
+    async (params) => {
+      const backend = backendFor('gpus');
+      if (backend.version === 'v1') {
+        return jsonReply({
+          error:
+            'get-gpu-type is only available on the v2 REST API. Set RUNPOD_REST_VERSION=v2 (or use list-gpu-types on v1).',
+          status: 501,
+        });
+      }
+      const result = await callRestUrl(
+        `${backend.base}${backend.get!(params.gpuTypeId)}`
+      );
+      return jsonReply(result);
     }
   );
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -5,14 +5,11 @@ import assert from 'node:assert/strict';
 // them before every test so a leak (from another test or the CI env) can't
 // silently flip v1 goldens to v2.
 beforeEach(() => {
-  for (const k of [
-    'RUNPOD_REST_VERSION',
-    'RUNPOD_REST_VERSION_PODS',
-    'RUNPOD_REST_VERSION_TEMPLATES',
-    'RUNPOD_REST_VERSION_NETWORK_VOLUMES',
-    'RUNPOD_REST_VERSION_REGISTRIES',
-  ]) {
-    delete process.env[k];
+  // Clear the global flag AND every per-resource override (RUNPOD_REST_VERSION_*)
+  // so a leak from CI/shell can't flip v1 goldens to v2 (or route a v1 catalog
+  // test to the real-network GraphQL path).
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith('RUNPOD_REST_VERSION')) delete process.env[k];
   }
 });
 
@@ -731,6 +728,49 @@ describe('catalog routing (B5)', () => {
     });
   });
 
+  it('list-gpu-types v2 communityCloudOnly filters on g.community', async () => {
+    await withV2(async () => {
+      const gpus = [
+        { id: 'a', name: 'A', community: false },
+        { id: 'b', name: 'B', community: true },
+      ];
+      const { handlers } = harness({ jsonBody: { gpus } });
+      const out = (await handlers.get('list-gpu-types')!({
+        communityCloudOnly: true,
+      })) as { content: Array<{ text: string }> };
+      const payload = JSON.parse(out.content[0].text);
+      assert.deepEqual(
+        payload.map((g: { id: string }) => g.id),
+        ['b']
+      );
+    });
+  });
+
+  it('list-gpu-types v2 includeUnavailable is a no-op (does not filter)', async () => {
+    await withV2(async () => {
+      const gpus = [
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'B' },
+      ];
+      const { handlers } = harness({ jsonBody: { gpus } });
+      const out = (await handlers.get('list-gpu-types')!({
+        includeUnavailable: false,
+      })) as { content: Array<{ text: string }> };
+      assert.equal(JSON.parse(out.content[0].text).length, 2);
+    });
+  });
+
+  it('list-gpu-types v2 no filters → returns all (unwrap only)', async () => {
+    await withV2(async () => {
+      const gpus = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+      const { handlers } = harness({ jsonBody: { gpus } });
+      const out = (await handlers.get('list-gpu-types')!({})) as {
+        content: Array<{ text: string }>;
+      };
+      assert.equal(JSON.parse(out.content[0].text).length, 3);
+    });
+  });
+
   it('list-gpu-types v2 searchTerm matches id/name', async () => {
     await withV2(async () => {
       const gpus = [
@@ -806,12 +846,21 @@ describe('catalog routing (B5)', () => {
       /only available on the v2/
     );
     await withV2(async () => {
-      const { handlers, outbound } = harness({ jsonBody: { id: 'a100' } });
-      await handlers.get('get-gpu-type')!({ gpuTypeId: 'a100' });
+      const { handlers, outbound } = harness({
+        jsonBody: { id: 'a100', memory: 80 },
+      });
+      const out = (await handlers.get('get-gpu-type')!({
+        gpuTypeId: 'a100',
+      })) as { content: Array<{ text: string }> };
       assert.equal(
         outbound[0].url,
         'https://v2-rest.runpod.io/v2/catalog/gpus/a100'
       );
+      // raw passthrough (no unwrap) — body preserved
+      assert.deepEqual(JSON.parse(out.content[0].text), {
+        id: 'a100',
+        memory: 80,
+      });
     });
   });
 });

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -697,6 +697,125 @@ describe('template / network-volume / registry routing under v2', () => {
   });
 });
 
+describe('catalog routing (B5)', () => {
+  it('list-gpu-types v2 → GET .../v2/catalog/gpus, unwraps + filters on v2 fields', async () => {
+    await withV2(async () => {
+      const gpus = [
+        {
+          id: 'a100',
+          name: 'A100',
+          memory: 80,
+          secure: true,
+          community: false,
+        },
+        {
+          id: 'rtx',
+          name: 'RTX 4090',
+          memory: 24,
+          secure: false,
+          community: true,
+        },
+      ];
+      const { handlers, outbound } = harness({ jsonBody: { gpus } });
+      const out = (await handlers.get('list-gpu-types')!({
+        minMemoryGb: 40,
+        secureCloudOnly: true,
+      })) as { content: Array<{ text: string }> };
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/catalog/gpus'
+      );
+      const payload = JSON.parse(out.content[0].text);
+      assert.equal(payload.length, 1);
+      assert.equal(payload[0].id, 'a100');
+    });
+  });
+
+  it('list-gpu-types v2 searchTerm matches id/name', async () => {
+    await withV2(async () => {
+      const gpus = [
+        { id: 'a100', name: 'A100', memory: 80 },
+        { id: 'rtx', name: 'RTX 4090', memory: 24 },
+      ];
+      const { handlers } = harness({ jsonBody: { gpus } });
+      const out = (await handlers.get('list-gpu-types')!({
+        searchTerm: '4090',
+      })) as { content: Array<{ text: string }> };
+      const payload = JSON.parse(out.content[0].text);
+      assert.equal(payload.length, 1);
+      assert.equal(payload[0].id, 'rtx');
+    });
+  });
+
+  it('list-data-centers v2 → GET .../v2/catalog/datacenters, region filter on enum', async () => {
+    await withV2(async () => {
+      const dataCenters = [
+        { id: 'US-TX-3', region: 'NORTH_AMERICA' },
+        { id: 'EU-RO-1', region: 'EUROPE' },
+      ];
+      const { handlers, outbound } = harness({ jsonBody: { dataCenters } });
+      const out = (await handlers.get('list-data-centers')!({
+        region: 'europe',
+      })) as { content: Array<{ text: string }> };
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/catalog/datacenters'
+      );
+      const payload = JSON.parse(out.content[0].text);
+      assert.equal(payload.length, 1);
+      assert.equal(payload[0].id, 'EU-RO-1');
+    });
+  });
+
+  it('list-cpu-types: v1 → clean "v2 only" message (no request); v2 → GET .../v2/catalog/cpus', async () => {
+    // v1
+    const v1 = harness({ jsonBody: {} });
+    assert.ok(v1.handlers.has('list-cpu-types'));
+    const v1out = (await v1.handlers.get('list-cpu-types')!({})) as {
+      content: Array<{ text: string }>;
+    };
+    assert.equal(v1.outbound.length, 0);
+    assert.match(
+      JSON.parse(v1out.content[0].text).error,
+      /only available on the v2/
+    );
+    // v2
+    await withV2(async () => {
+      const { handlers, outbound } = harness({
+        jsonBody: { cpus: [{ id: 'cpu5c' }] },
+      });
+      const out = (await handlers.get('list-cpu-types')!({})) as {
+        content: Array<{ text: string }>;
+      };
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/catalog/cpus'
+      );
+      assert.deepEqual(JSON.parse(out.content[0].text), [{ id: 'cpu5c' }]);
+    });
+  });
+
+  it('get-gpu-type: v1 → clean message; v2 → GET .../v2/catalog/gpus/{id}', async () => {
+    const v1 = harness({ jsonBody: {} });
+    const v1out = (await v1.handlers.get('get-gpu-type')!({
+      gpuTypeId: 'a100',
+    })) as { content: Array<{ text: string }> };
+    assert.equal(v1.outbound.length, 0);
+    assert.match(
+      JSON.parse(v1out.content[0].text).error,
+      /only available on the v2/
+    );
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { id: 'a100' } });
+      await handlers.get('get-gpu-type')!({ gpuTypeId: 'a100' });
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/catalog/gpus/a100'
+      );
+    });
+  });
+});
+
 describe('stream-job poll loop (sequenced responses)', () => {
   it('polls /v2/{id}/stream/{jobId} until a terminal status', async () => {
     const { handlers, outbound } = harness({


### PR DESCRIPTION
**Stacked draft — do not merge.** Base = `v2/phase-c1-c2-newtools-501` (PR #40). Implements **B5** + the remaining **C1** catalog tools.

## Changes
- **`list-gpu-types` / `list-data-centers`**: v1 GraphQL path **unchanged**; under v2 route to REST `/v2/catalog/gpus` / `/v2/catalog/datacenters`, unwrap the envelope, and re-apply the client-side filters against v2 field names (`memory`/`secure`/`community`/`name`; `region` enum for DCs). `includeUnavailable` is a **documented no-op** on v2 (v2 has no realtime `stockStatus`).
- **NEW `list-cpu-types`** (`/v2/catalog/cpus`) and **`get-gpu-type`** (`/v2/catalog/gpus/{id}`): v2-only; under v1 they return a clean "v2 only" message with no network call.

## Tests
- v2 catalog goldens: list-gpu-types (filters on v2 fields + searchTerm), list-data-centers (region enum), list-cpu-types (v1 message + v2 path), get-gpu-type (v1 message + v2 path).
- **159 pass** · `tsc`/`eslint`/`tsup` clean.
- Note: the v1 catalog GraphQL path is intentionally **not** invoked in tests (it uses the module `fetch`, not the injected client, so it would hit the network). v1 catalog behavior is unchanged from `main`.

## Remaining after this
**C3** (wire `createV2Prober` into stdio for `auto` + flip default when v2 prod live) and **B6** (live CRUD smoke). That completes the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)