### PR TITLE
[Phase C · PR9] Wire createV2Prober into stdio for auto mode (C3)

### DIFF
--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -155,14 +155,23 @@ export function wantsAutoProbe(env: Env): boolean {
 // exact shape the prober needs (just `{ status }`), instead of casting.
 export type FetchLike = (
   url: string,
-  init?: { method?: string; headers?: Record<string, string> }
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  }
 ) => Promise<{ status: number }>;
 
 export interface ProbeDeps {
   fetch: FetchLike;
   baseUrl: string;
   apiKey: string;
+  timeoutMs?: number;
 }
+
+// Bound the startup probe so a slow-but-reachable v2 host can't hang stdio
+// startup forever — an abort throws, which runV2Probe degrades to a transient.
+export const PROBE_TIMEOUT_MS = 4000;
 
 // Classify a probe response status into a definitive verdict, or `undefined` for
 // a transient failure (5xx) that must NOT be cached.
@@ -172,12 +181,13 @@ function classifyProbeStatus(status: number): boolean | undefined {
 }
 
 // One probe attempt. Returns a definitive verdict, or `undefined` when the
-// attempt was transient (network throw / 5xx) and should be retried.
+// attempt was transient (network throw / timeout / 5xx) and should be retried.
 async function runV2Probe(deps: ProbeDeps): Promise<boolean | undefined> {
   try {
     const res = await deps.fetch(`${deps.baseUrl}/catalog/gpus`, {
       method: 'GET',
       headers: { Authorization: `Bearer ${deps.apiKey}` },
+      signal: AbortSignal.timeout(deps.timeoutMs ?? PROBE_TIMEOUT_MS),
     });
     return classifyProbeStatus(res.status);
   } catch {

--- a/src/_shared/backend.ts
+++ b/src/_shared/backend.ts
@@ -132,6 +132,15 @@ export function resolveVersion(opts: {
   return 'v1';
 }
 
+// True if any version setting (global or per-resource) is `auto` — i.e. the
+// stdio entrypoint should run the v2 probe once at startup. Pure.
+export function wantsAutoProbe(env: Env): boolean {
+  return Object.entries(env).some(
+    ([k, v]) =>
+      k.startsWith('RUNPOD_REST_VERSION') && (v ?? '').toLowerCase() === 'auto'
+  );
+}
+
 // ---- A1b: the real `auto` probe (decision logic, injected fetch) ----
 // Returns an async resolver that probes once and memoizes the verdict for the
 // process. The startup wiring (stdio only) awaits this once, then passes the

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,6 +1,12 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import fetch from 'node-fetch';
 import { createServer } from './server.js';
 import { registerTools } from './tools.js';
+import {
+  createV2Prober,
+  restV2Base,
+  wantsAutoProbe,
+} from './_shared/backend.js';
 
 // Get API key from environment variable
 const API_KEY = process.env.RUNPOD_API_KEY;
@@ -9,11 +15,27 @@ if (!API_KEY) {
   process.exit(1);
 }
 
-const server = createServer();
+async function main(apiKey: string): Promise<void> {
+  // `auto` mode (stdio only): probe v2 once at startup and pass the resolved
+  // verdict to the tools. Explicit v1/v2 needs no probe.
+  let v2Available: boolean | undefined;
+  if (wantsAutoProbe(process.env)) {
+    const probe = createV2Prober({
+      fetch: fetch as unknown as Parameters<typeof createV2Prober>[0]['fetch'],
+      baseUrl: restV2Base(process.env),
+      apiKey,
+    });
+    v2Available = await probe();
+  }
 
-// Register all tools with the API key from the environment
-registerTools(server, { apiKey: API_KEY, transport: 'stdio' });
+  const server = createServer();
+  registerTools(server, { apiKey, transport: 'stdio' }, { v2Available });
 
-// Start receiving messages on stdin and sending messages on stdout
-const transport = new StdioServerTransport();
-server.connect(transport);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main(API_KEY).catch((error) => {
+  console.error('Failed to start Runpod MCP server:', error);
+  process.exit(1);
+});

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -6,6 +6,7 @@ import {
   createV2Prober,
   restV2Base,
   wantsAutoProbe,
+  type FetchLike,
 } from './_shared/backend.js';
 
 // Get API key from environment variable
@@ -21,7 +22,8 @@ async function main(apiKey: string): Promise<void> {
   let v2Available: boolean | undefined;
   if (wantsAutoProbe(process.env)) {
     const probe = createV2Prober({
-      fetch: fetch as unknown as Parameters<typeof createV2Prober>[0]['fetch'],
+      // node-fetch's signature is wider than the `{ status }` the prober needs.
+      fetch: fetch as unknown as FetchLike,
       baseUrl: restV2Base(process.env),
       apiKey,
     });

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -6,8 +6,25 @@ import {
   resolveVersion,
   createV2Prober,
   resolveBackend,
+  wantsAutoProbe,
   type Resource,
 } from '../src/_shared/backend.js';
+
+describe('wantsAutoProbe', () => {
+  it('true when the global flag is auto (any case)', () => {
+    assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'auto' }), true);
+    assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'AUTO' }), true);
+  });
+  it('true when a per-resource override is auto', () => {
+    assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION_PODS: 'auto' }), true);
+  });
+  it('false for v1/v2/unset/bogus', () => {
+    assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'v2' }), false);
+    assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'v1' }), false);
+    assert.equal(wantsAutoProbe({}), false);
+    assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'foo' }), false);
+  });
+});
 
 // ============== A0: unwrapList ==============
 describe('unwrapList', () => {

--- a/tests/backend.test.ts
+++ b/tests/backend.test.ts
@@ -18,11 +18,18 @@ describe('wantsAutoProbe', () => {
   it('true when a per-resource override is auto', () => {
     assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION_PODS: 'auto' }), true);
   });
-  it('false for v1/v2/unset/bogus', () => {
+  it('false for v1/v2/unset/bogus/empty', () => {
     assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'v2' }), false);
     assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'v1' }), false);
     assert.equal(wantsAutoProbe({}), false);
     assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: 'foo' }), false);
+    assert.equal(wantsAutoProbe({ RUNPOD_REST_VERSION: '' }), false);
+  });
+  it('startsWith matches any suffix incl. V1_ONLY (intentional over-match; harmless)', () => {
+    assert.equal(
+      wantsAutoProbe({ RUNPOD_REST_VERSION_ENDPOINTS: 'auto' }),
+      true
+    );
   });
 });
 
@@ -246,6 +253,21 @@ describe('createV2Prober', () => {
         `status ${status} should not be available`
       );
     }
+  });
+
+  it('passes an AbortSignal (timeout) and degrades an aborted probe to false', async () => {
+    let sawSignal = false;
+    const probe = createV2Prober({
+      fetch: async (_url, init) => {
+        sawSignal = init?.signal instanceof AbortSignal;
+        throw new Error('aborted'); // simulate a timeout abort
+      },
+      baseUrl: 'x',
+      apiKey: 'k',
+      timeoutMs: 10,
+    });
+    assert.equal(await probe(), false);
+    assert.equal(sawSignal, true, 'probe must pass a timeout signal');
   });
 
   it('fetch throws → false', async () => {


### PR DESCRIPTION
**Stacked draft — do not merge.** Base = `v2/phase-b5-catalog-rest` (PR #41). Implements **C3** (the `auto`-mode probe wiring; the deploy-time default flip stays a config/env decision).

## Changes
- **`src/stdio.ts`**: if any `RUNPOD_REST_VERSION*` is `auto` (`wantsAutoProbe`), probe v2 once at startup via `createV2Prober` and pass the resolved `v2Available` boolean into `registerTools`. Explicit `v1`/`v2` skips the probe. Startup wrapped in `async main()`.
- **`src/_shared/backend.ts`**: new pure `wantsAutoProbe(env)` helper (unit-tested).
- `auto` remains **stdio-only** — hosted HTTP pins per-deploy and `resolveVersion` already treats `auto` as v1 under `http` (no cross-user probe leak).

## Tests
- `wantsAutoProbe`: global auto (any case), per-resource auto, false for v1/v2/unset/bogus.
- **165 pass** · `tsc`/`eslint`/`tsup` clean. (`createV2Prober` decision logic was already unit-tested in PR #34.)

## Remaining
**B6** — live CRUD smoke against the dev account with teardown (a manual/CI script, not an offline unit test). That's the last item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)