### PR TITLE
fix: expose containerRegistryAuthId on create/update-template

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1283,6 +1283,12 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
         .string()
         .optional()
         .describe('README content in markdown format'),
+      containerRegistryAuthId: z
+        .string()
+        .optional()
+        .describe(
+          'ID of a container registry credential (from create-container-registry-auth / list-container-registry-auths) used to pull a private image. Required when imageName points at a private registry; without it serverless workers fail the image pull.'
+        ),
     },
     async (params) => {
       const result = await runpodRequest('/templates', 'POST', params);
@@ -1314,6 +1320,12 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
         .string()
         .optional()
         .describe('New README content in markdown format'),
+      containerRegistryAuthId: z
+        .string()
+        .optional()
+        .describe(
+          'ID of a container registry credential (from create-container-registry-auth / list-container-registry-auths) used to pull a private image. Set this to attach a credential to a template referencing a private registry.'
+        ),
     },
     async (params) => {
       const { templateId, ...updateParams } = params;


### PR DESCRIPTION
Closes DR-1396

## Problem

`create-template` / `update-template` lack a parameter to set container registry credentials. Templates created or updated via MCP that reference a **private image** are saved with `containerRegistryAuthId: null`, so serverless workers fail the image pull and cycle unhealthy until the credential is attached manually in the web console.

The registry-auth tools (`create-container-registry-auth`, `list-container-registry-auths`) already exist, but there was no way to **link** a credential to a template. Read APIs (`get-endpoint` / `list-endpoints`) already expose `template.containerRegistryAuthId`, confirming a write-path gap.

Reported via Zendesk #41478 (customer: conrad@rockenhaus.net).

## Fix

Schema-only change — `params` already passes straight through to the REST call, and the REST write path accepts `containerRegistryAuthId`. Adds an optional `containerRegistryAuthId` to both `create-template` and `update-template`, with a description pointing at the registry-auth tools.

## Verification

- `tsc --noEmit` ✓
- `eslint src/tools.ts` ✓
- `pnpm build` ✓
- `pnpm test` ✓ (16/16)

## Notes

- This is the **v1** field name (`containerRegistryAuthId`). In the in-flight v2 REST migration the field is renamed `registry` and lives in the shared `ContainerConfig` (templates + pods + endpoints) — the same gap will be closed there separately; this PR is the fast customer unblock on `main`.

