### PR TITLE
[v2 5/5] Advertise S256 PKCE so Claude Code can start the OAuth flow

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -235,9 +235,15 @@ function handleAuthorizationServerMetadata(
     response_types_supported: ['code'],
     grant_types_supported: ['authorization_code'],
     token_endpoint_auth_methods_supported: ['none'],
-    // Note: PKCE is intentionally not advertised because it is not enforced
-    // server-side (the flash flow has no place to bind the code_challenge).
-    // Security rests on the redirect_uri allowlist + single-use flash approval.
+    // Advertise S256 PKCE so OAuth clients that require it (e.g. Claude Code,
+    // which refuses to start the flow without this field per RFC 8414/8252)
+    // will proceed. NOTE: the code_challenge is not yet verified server-side —
+    // the stateless function has nowhere to bind it across /authorize→/token.
+    // Until enforcement lands (persist code_challenge on the flash auth request
+    // and check the verifier at /token), the flow's real protection remains the
+    // redirect_uri allowlist + single-use, short-lived, human-approved flash
+    // request. Advertising S256 here unblocks clients without weakening that.
+    code_challenge_methods_supported: ['S256'],
   });
 }
 


### PR DESCRIPTION
Stacked on #47 (`v2/group-4-source-split`).

**Why this PR:** Claude Code (and other RFC 8414 OAuth clients) refuse to start the sign-in flow unless the server advertises `S256` PKCE in its discovery metadata. Ours didn't, so "Sign in with Runpod" failed before the browser ever opened. This one-line metadata fix unblocks them. **Enforcing** the challenge is a tracked follow-up — see below.

## The stack (review / merge in order)
1. **#44 — Adapter foundation** (no behavior change)
2. **#45 — Route every resource through the adapter** (v1 + v2)
3. **#46 — New capabilities** (restart-pod, 501, auto-probe)
4. **#47 — Split, endpoint CRUD → v2, new tools, spec-parity gate**
5. **#49 — Advertise S256 PKCE so OAuth clients (Claude Code) can start the flow** (tip) ← you are here

## Problem
Clients read `/.well-known/oauth-authorization-server` during discovery and **refuse to start the flow** unless `code_challenge_methods_supported` lists `S256`. Our metadata omitted the field, so the flow errored before the browser opened.

## Change
One line in `handleAuthorizationServerMetadata` (`api/index.ts`):
```json
"code_challenge_methods_supported": ["S256"]
```

## Important: advertise-only for now (deliberate stopgap)
The `code_challenge` is **not yet verified** server-side. The MCP server is a stateless Vercel function with nowhere to bind the challenge across the `/authorize` → `/token` boundary (and `/authorize` doesn't even mint the code — the console does, from the flash `requestId`). So this PR makes the discovery check pass; it does not yet enforce PKCE.

This is acceptable as a stopgap because the flow's real protection does not depend on PKCE — all authorization is flash/console-side:
- the authorization code is the flash request id — **single-use, ~10-min TTL, requires a human to approve in the console**, and
- the code is only ever delivered to an **allowlisted redirect_uri** (`claude.ai` / `claude.com` / loopback), re-checked at both `/authorize` and `/token`.

The one path where verified PKCE would add real protection is **loopback** (native-app interception); the compensating controls blunt it but don't fully close it.

## Follow-up — tracked in **[DR-1398](https://linear.app/runpod/issue/DR-1398)** (High priority)
Enforce S256 by storing `code_challenge` across the boundary and verifying `base64url(sha256(code_verifier))` at `/token` (reject `invalid_grant` on mismatch), plus **require PKCE for loopback** redirects. Two implementation options in the ticket: (A) persist on the `FlashAuthRequest` row (`model/src/flash/authRequests.ts` + flash GraphQL) — recommended; (B) Vercel KV keyed by `requestId` — MCP-only, no backend change.

**We will not advertise "PKCE supported" as a security feature publicly until enforcement lands** — the discovery metadata stays (it's a compatibility shim), but no changelog/marketing claim until DR-1398 is done.

## Test
Deploy a preview, connect Claude Code with no key, confirm "Sign in with Runpod" now gets past discovery and completes.
