### PR TITLE
feat: DR-1398 enforce PKCE (S256) in hosted OAuth /token

### DIFF
--- a/.changeset/dr-1398-enforce-pkce-s256.md
+++ b/.changeset/dr-1398-enforce-pkce-s256.md
@@ -1,0 +1,7 @@
+---
+'@runpod/mcp-server': minor
+---
+
+Enforce PKCE (S256) in the hosted OAuth flow. `/authorize` now forwards the client's `code_challenge` to the flash backend, and `/token` verifies the `code_verifier` against the stored challenge before returning the minted key: a missing or non-matching verifier is rejected with `invalid_grant`, and `plain` is rejected (only S256 is advertised/accepted). Loopback redirect URIs now require PKCE (the native-app interception case it protects); hosted exact-match redirects may still use the legacy non-PKCE flow.
+
+Requires the backend `codeChallenge` / `codeChallengeMethod` fields on `createFlashAuthRequest` / `flashAuthRequestStatus` (runpod/RunPod, DR-1398) to be deployed.

--- a/.changeset/dr-1398-enforce-pkce-s256.md
+++ b/.changeset/dr-1398-enforce-pkce-s256.md
@@ -2,6 +2,6 @@
 '@runpod/mcp-server': minor
 ---
 
-Enforce PKCE (S256) in the hosted OAuth flow. `/authorize` now forwards the client's `code_challenge` to the flash backend, and `/token` verifies the `code_verifier` against the stored challenge before returning the minted key: a missing or non-matching verifier is rejected with `invalid_grant`, and `plain` is rejected (only S256 is advertised/accepted). Loopback redirect URIs now require PKCE (the native-app interception case it protects); hosted exact-match redirects may still use the legacy non-PKCE flow.
+Enforce PKCE (S256) in every hosted OAuth flow. `/authorize` rejects missing, malformed, or non-S256 challenges before issuing a code and forwards a valid challenge to the flash backend. `/token` requires a valid, matching `code_verifier` before returning the minted key; missing PKCE state, `plain`, and non-matching verifiers are rejected.
 
 Requires the backend `codeChallenge` / `codeChallengeMethod` fields on `createFlashAuthRequest` / `flashAuthRequestStatus` (runpod/RunPod, DR-1398) to be deployed.

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { handleMcpRequest } from '../src/http.js';
+import { isLoopbackHost, verifyPkce } from '../src/oauth/pkce.js';
 
 // Read the package version at runtime. tsup's build-time `__PACKAGE_VERSION__`
 // define does not run here because Vercel compiles api/index.ts itself, so the
@@ -65,11 +66,6 @@ function getAllowedRedirectUris(): string[] {
   return [...DEFAULT_ALLOWED_REDIRECT_URIS, ...extra];
 }
 
-function isLoopbackHost(hostname: string): boolean {
-  const h = hostname.replace(/^\[|\]$/g, '');
-  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
-}
-
 /**
  * Whether we may deliver the authorization code to this redirect_uri. Loopback
  * (http, any port) is always allowed for native clients; everything else must
@@ -110,6 +106,8 @@ interface FlashAuthRequestStatus {
   id: string;
   status: 'PENDING' | 'APPROVED' | 'DENIED' | 'EXPIRED' | 'CONSUMED';
   apiKey: string | null;
+  codeChallenge: string | null;
+  codeChallengeMethod: string | null;
 }
 
 /**
@@ -153,9 +151,19 @@ async function flashGraphql<T>(query: string, field: string): Promise<T> {
  * Create a pending flash auth request (guest mutation, no auth header) and
  * return its id. The id doubles as the OAuth authorization code.
  */
-async function createFlashAuthRequest(): Promise<string> {
+async function createFlashAuthRequest(
+  codeChallenge?: string | null,
+  codeChallengeMethod?: string | null
+): Promise<string> {
+  const parts: string[] = [];
   const apiKeyName = getApiKeyName();
-  const args = apiKeyName ? `(apiKeyName: ${JSON.stringify(apiKeyName)})` : '';
+  if (apiKeyName) parts.push(`apiKeyName: ${JSON.stringify(apiKeyName)}`);
+  // Only sent when the client supplied a challenge, so a non-PKCE flow never
+  // references the arg (which requires the DR-1398 backend field to be deployed).
+  if (codeChallenge) parts.push(`codeChallenge: ${JSON.stringify(codeChallenge)}`);
+  if (codeChallengeMethod)
+    parts.push(`codeChallengeMethod: ${JSON.stringify(codeChallengeMethod)}`);
+  const args = parts.length ? `(${parts.join(', ')})` : '';
   const data = await flashGraphql<{ id: string }>(
     `mutation { createFlashAuthRequest${args} { id } }`,
     'createFlashAuthRequest'
@@ -171,7 +179,7 @@ async function getFlashAuthStatus(id: string): Promise<FlashAuthRequestStatus> {
   return flashGraphql<FlashAuthRequestStatus>(
     `query { flashAuthRequestStatus(flashAuthRequestId: ${JSON.stringify(
       id
-    )}) { id status apiKey } }`,
+    )}) { id status apiKey codeChallenge codeChallengeMethod } }`,
     'flashAuthRequestStatus'
   );
 }
@@ -236,13 +244,9 @@ function handleAuthorizationServerMetadata(
     grant_types_supported: ['authorization_code'],
     token_endpoint_auth_methods_supported: ['none'],
     // Advertise S256 PKCE so OAuth clients that require it (e.g. Claude Code,
-    // which refuses to start the flow without this field per RFC 8414/8252)
-    // will proceed. NOTE: the code_challenge is not yet verified server-side —
-    // the stateless function has nowhere to bind it across /authorize→/token.
-    // Until enforcement lands (persist code_challenge on the flash auth request
-    // and check the verifier at /token), the flow's real protection remains the
-    // redirect_uri allowlist + single-use, short-lived, human-approved flash
-    // request. Advertising S256 here unblocks clients without weakening that.
+    // per RFC 8414/8252) will start the flow. This is now enforced: /authorize
+    // persists the code_challenge on the flash auth request and /token verifies
+    // the code_verifier against it before returning the key (see verifyPkce).
     code_challenge_methods_supported: ['S256'],
   });
 }
@@ -288,6 +292,10 @@ async function handleAuthorize(
     const requestUrl = new URL(req.url ?? '/', getBaseUrl(req));
     const redirectUri = requestUrl.searchParams.get('redirect_uri');
     const state = requestUrl.searchParams.get('state');
+    const codeChallenge = requestUrl.searchParams.get('code_challenge');
+    const codeChallengeMethod = requestUrl.searchParams.get(
+      'code_challenge_method'
+    );
 
     // Reject before doing anything: the authorization code redeems into a real
     // API key, so we only ever deliver it to an allowlisted redirect_uri.
@@ -301,8 +309,12 @@ async function handleAuthorize(
       return;
     }
 
-    // 1. Create a guest flash auth request; its id is the OAuth code.
-    const requestId = await createFlashAuthRequest();
+    // 1. Create a guest flash auth request; its id is the OAuth code. The PKCE
+    //    challenge (if any) is persisted with it and verified at /token.
+    const requestId = await createFlashAuthRequest(
+      codeChallenge,
+      codeChallengeMethod
+    );
 
     console.log('oauth_authorize', {
       clientId: requestUrl.searchParams.get('client_id'),
@@ -420,7 +432,25 @@ async function handleToken(
         attempt,
         status: status.status,
         hasApiKey: !!status.apiKey,
+        hasCodeChallenge: !!status.codeChallenge,
       });
+
+      // PKCE gate — run before honoring an APPROVED request so a missing/wrong
+      // verifier never yields a key. On a PENDING poll this rejects a bad
+      // verifier early, before the user approves. (An APPROVED read consumes the
+      // code atomically in the backend, so a failure there still burns the code;
+      // the key is never returned, which is the property PKCE protects.)
+      const pkceError = verifyPkce({
+        codeChallenge: status.codeChallenge,
+        codeChallengeMethod: status.codeChallengeMethod,
+        codeVerifier: params.get('code_verifier'),
+        redirectUri: params.get('redirect_uri'),
+      });
+      if (pkceError) {
+        console.warn('oauth_token_pkce_rejected', { attempt });
+        tokenError(res, 400, 'invalid_grant', pkceError);
+        return;
+      }
 
       if (status.status === 'APPROVED' || status.status === 'CONSUMED') {
         if (!status.apiKey) {

--- a/api/index.ts
+++ b/api/index.ts
@@ -6,6 +6,7 @@ import { handleMcpRequest } from '../src/http.js';
 import {
   isLoopbackHost,
   validatePkceAuthorization,
+  validatePkceVerifier,
   verifyPkce,
 } from '../src/oauth/pkce.js';
 
@@ -155,18 +156,13 @@ async function flashGraphql<T>(query: string, field: string): Promise<T> {
  * Create a pending flash auth request (guest mutation, no auth header) and
  * return its id. The id doubles as the OAuth authorization code.
  */
-async function createFlashAuthRequest(
-  codeChallenge?: string | null,
-  codeChallengeMethod?: string | null
-): Promise<string> {
+async function createFlashAuthRequest(codeChallenge: string): Promise<string> {
   const parts: string[] = [];
   const apiKeyName = getApiKeyName();
   if (apiKeyName) parts.push(`apiKeyName: ${JSON.stringify(apiKeyName)}`);
   // These fields require the DR-1398 backend schema to be deployed.
-  if (codeChallenge)
-    parts.push(`codeChallenge: ${JSON.stringify(codeChallenge)}`);
-  if (codeChallengeMethod)
-    parts.push(`codeChallengeMethod: ${JSON.stringify(codeChallengeMethod)}`);
+  parts.push(`codeChallenge: ${JSON.stringify(codeChallenge)}`);
+  parts.push('codeChallengeMethod: "S256"');
   const args = parts.length ? `(${parts.join(', ')})` : '';
   const data = await flashGraphql<{ id: string }>(
     `mutation { createFlashAuthRequest${args} { id } }`,
@@ -315,25 +311,22 @@ async function handleAuthorize(
 
     // Require the advertised S256 PKCE policy before issuing an authorization
     // code. This applies to every client; there is no legacy non-PKCE path.
-    const pkceRequestError = validatePkceAuthorization({
+    const pkceRequest = validatePkceAuthorization({
       codeChallenge,
       codeChallengeMethod,
     });
-    if (pkceRequestError) {
+    if (!pkceRequest.ok) {
       console.warn('oauth_authorize_pkce_rejected');
       res.status(400).json({
         error: 'invalid_request',
-        error_description: pkceRequestError,
+        error_description: pkceRequest.error,
       });
       return;
     }
 
     // 1. Create a guest flash auth request; its id is the OAuth code. The PKCE
     //    challenge is persisted with it and verified at /token.
-    const requestId = await createFlashAuthRequest(
-      codeChallenge,
-      codeChallengeMethod
-    );
+    const requestId = await createFlashAuthRequest(pkceRequest.codeChallenge);
 
     console.log('oauth_authorize', {
       clientId: requestUrl.searchParams.get('client_id'),
@@ -399,13 +392,14 @@ async function handleToken(
   const params = new URLSearchParams(encodeBody(req.body));
   const grantType = params.get('grant_type');
   const code = params.get('code');
+  const codeVerifier = params.get('code_verifier');
 
   console.log('oauth_token_request', {
     grantType,
     hasCode: !!code,
     redirectUri: params.get('redirect_uri'),
     clientId: params.get('client_id'),
-    hasCodeVerifier: !!params.get('code_verifier'),
+    hasCodeVerifier: !!codeVerifier,
   });
 
   if (grantType !== 'authorization_code') {
@@ -430,6 +424,14 @@ async function handleToken(
       'invalid_grant',
       'redirect_uri is missing or not allowed.'
     );
+    return;
+  }
+
+  // Reject verifier syntax before reading backend status. An APPROVED status
+  // read consumes the authorization code, so malformed requests must fail first.
+  const verifierRequest = validatePkceVerifier(codeVerifier);
+  if (!verifierRequest.ok) {
+    tokenError(res, 400, 'invalid_grant', verifierRequest.error);
     return;
   }
 
@@ -462,7 +464,7 @@ async function handleToken(
       const pkceError = verifyPkce({
         codeChallenge: status.codeChallenge,
         codeChallengeMethod: status.codeChallengeMethod,
-        codeVerifier: params.get('code_verifier'),
+        codeVerifier: verifierRequest.codeVerifier,
       });
       if (pkceError) {
         console.warn('oauth_token_pkce_rejected', { attempt });

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,7 +3,11 @@ import fetch from 'node-fetch';
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { handleMcpRequest } from '../src/http.js';
-import { isLoopbackHost, verifyPkce } from '../src/oauth/pkce.js';
+import {
+  isLoopbackHost,
+  validatePkceAuthorization,
+  verifyPkce,
+} from '../src/oauth/pkce.js';
 
 // Read the package version at runtime. tsup's build-time `__PACKAGE_VERSION__`
 // define does not run here because Vercel compiles api/index.ts itself, so the
@@ -158,9 +162,9 @@ async function createFlashAuthRequest(
   const parts: string[] = [];
   const apiKeyName = getApiKeyName();
   if (apiKeyName) parts.push(`apiKeyName: ${JSON.stringify(apiKeyName)}`);
-  // Only sent when the client supplied a challenge, so a non-PKCE flow never
-  // references the arg (which requires the DR-1398 backend field to be deployed).
-  if (codeChallenge) parts.push(`codeChallenge: ${JSON.stringify(codeChallenge)}`);
+  // These fields require the DR-1398 backend schema to be deployed.
+  if (codeChallenge)
+    parts.push(`codeChallenge: ${JSON.stringify(codeChallenge)}`);
   if (codeChallengeMethod)
     parts.push(`codeChallengeMethod: ${JSON.stringify(codeChallengeMethod)}`);
   const args = parts.length ? `(${parts.join(', ')})` : '';
@@ -309,8 +313,23 @@ async function handleAuthorize(
       return;
     }
 
+    // Require the advertised S256 PKCE policy before issuing an authorization
+    // code. This applies to every client; there is no legacy non-PKCE path.
+    const pkceRequestError = validatePkceAuthorization({
+      codeChallenge,
+      codeChallengeMethod,
+    });
+    if (pkceRequestError) {
+      console.warn('oauth_authorize_pkce_rejected');
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: pkceRequestError,
+      });
+      return;
+    }
+
     // 1. Create a guest flash auth request; its id is the OAuth code. The PKCE
-    //    challenge (if any) is persisted with it and verified at /token.
+    //    challenge is persisted with it and verified at /token.
     const requestId = await createFlashAuthRequest(
       codeChallenge,
       codeChallengeMethod
@@ -444,7 +463,6 @@ async function handleToken(
         codeChallenge: status.codeChallenge,
         codeChallengeMethod: status.codeChallengeMethod,
         codeVerifier: params.get('code_verifier'),
-        redirectUri: params.get('redirect_uri'),
       });
       if (pkceError) {
         console.warn('oauth_token_pkce_rejected', { attempt });

--- a/scripts/oauth-e2e.ts
+++ b/scripts/oauth-e2e.ts
@@ -14,12 +14,20 @@
  * Env:
  *   MCP_SERVER_URL   hosted MCP base URL (required)
  */
+import { randomBytes } from 'node:crypto';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { s256 } from '../src/oauth/pkce.js';
 
 const MCP = process.env.MCP_SERVER_URL;
 if (!MCP) throw new Error('MCP_SERVER_URL is required');
 const base = MCP.replace(/\/$/, '');
+
+// Real PKCE pair for this run: a random verifier and its S256 challenge. The
+// happy path sends the matching verifier at /token; the negative check below
+// sends a non-matching one and expects `invalid_grant`.
+const codeVerifier = randomBytes(32).toString('base64url');
+const codeChallenge = s256(codeVerifier);
 
 function log(step: string, data: unknown) {
   console.log(`\n[${step}]`, JSON.stringify(data, null, 2));
@@ -28,14 +36,10 @@ function log(step: string, data: unknown) {
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /**
- * POST the token endpoint once. Returns the parsed JSON body + HTTP status.
- *
- * PKCE test: we sent `code_challenge=challenge-abc` at /authorize but send a
- * deliberately NON-matching `code_verifier` here. If the token is still minted,
- * the server is not enforcing PKCE (S256 would require the verifier to hash to
- * the challenge).
+ * POST the token endpoint once with the given `code_verifier`. Returns the
+ * parsed JSON body + HTTP status.
  */
-async function postToken(code: string) {
+async function postToken(code: string, verifier: string) {
   const res = await fetch(`${base}/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -43,7 +47,7 @@ async function postToken(code: string) {
       grant_type: 'authorization_code',
       code,
       redirect_uri: 'http://localhost:8765/callback',
-      code_verifier: 'this-verifier-does-not-match-the-challenge',
+      code_verifier: verifier,
     }).toString(),
   });
   const body = (await res.json()) as Record<string, unknown>;
@@ -75,7 +79,7 @@ async function main() {
   const authRes = await fetch(
     `${base}/authorize?client_id=${reg.client_id}&redirect_uri=${encodeURIComponent(
       'http://localhost:8765/callback'
-    )}&state=e2e&code_challenge=challenge-abc&code_challenge_method=S256&response_type=code`,
+    )}&state=e2e&code_challenge=${codeChallenge}&code_challenge_method=S256&response_type=code`,
     { redirect: 'manual' }
   );
   const location = authRes.headers.get('location') ?? '';
@@ -87,14 +91,25 @@ async function main() {
   const code = inner.searchParams.get('request')!;
   log('authorize', { status: authRes.status, code, consoleUrl: location });
 
-  // 4. Approve (manual) + 5. poll /token for the minted key. We only call the
-  // MCP's own token endpoint — it polls the backend server-side and returns the
-  // minted key once the request is APPROVED.
+  // 4. PKCE enforcement check — a non-matching verifier must be rejected with
+  // `invalid_grant`, and the rejection happens before approval (the verifier is
+  // checked on every /token poll). If this mints or pends, PKCE isn't enforced.
+  const bad = await postToken(code, 'this-verifier-does-not-match-the-challenge');
+  if (bad.body.error !== 'invalid_grant') {
+    throw new Error(
+      `PKCE not enforced: bad verifier expected invalid_grant, got ${JSON.stringify(bad.body)}`
+    );
+  }
+  log('pkce-enforced', { status: bad.status, error: bad.body.error });
+
+  // 5. Approve (manual) + 6. poll /token with the MATCHING verifier for the
+  // minted key. We only call the MCP's own token endpoint — it polls the backend
+  // server-side and returns the minted key once the request is APPROVED.
   console.log('\n[approve] Open and approve in your browser:\n' + location);
   process.stdout.write('[token] polling');
   let key: string | undefined;
   for (let i = 0; i < 30; i++) {
-    const { body } = await postToken(code);
+    const { body } = await postToken(code, codeVerifier);
     if (typeof body.access_token === 'string') {
       key = body.access_token;
       break;

--- a/scripts/oauth-e2e.ts
+++ b/scripts/oauth-e2e.ts
@@ -54,6 +54,28 @@ async function postToken(code: string, verifier: string) {
   return { status: res.status, body };
 }
 
+async function expectAuthorizeRejected(
+  clientId: string,
+  label: string,
+  pkce: Record<string, string>
+) {
+  const url = new URL(`${base}/authorize`);
+  url.search = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: 'http://localhost:8765/callback',
+    response_type: 'code',
+    ...pkce,
+  }).toString();
+  const res = await fetch(url, { redirect: 'manual' });
+  const body = (await res.json()) as Record<string, unknown>;
+  if (res.status !== 400 || body.error !== 'invalid_request') {
+    throw new Error(
+      `${label}: expected 400 invalid_request, got ${res.status} ${JSON.stringify(body)}`
+    );
+  }
+  log(label, { status: res.status, error: body.error });
+}
+
 async function main() {
   // 1. Discovery
   const asMeta = await (
@@ -75,7 +97,18 @@ async function main() {
   ).json();
   log('register', { client_id: reg.client_id });
 
-  // 3. /authorize -> capture console handoff + flash request id (= the OAuth code)
+  // 3. Invalid authorization requests must fail before a flash request/code is
+  // created. This proves there is no hosted or loopback non-PKCE fallback.
+  await expectAuthorizeRejected(reg.client_id, 'pkce-required', {});
+  await expectAuthorizeRejected(reg.client_id, 'pkce-method-required', {
+    code_challenge: codeChallenge,
+  });
+  await expectAuthorizeRejected(reg.client_id, 'pkce-plain-rejected', {
+    code_challenge: codeChallenge,
+    code_challenge_method: 'plain',
+  });
+
+  // 4. Valid /authorize -> capture console handoff + flash request id (= code)
   const authRes = await fetch(
     `${base}/authorize?client_id=${reg.client_id}&redirect_uri=${encodeURIComponent(
       'http://localhost:8765/callback'
@@ -91,10 +124,10 @@ async function main() {
   const code = inner.searchParams.get('request')!;
   log('authorize', { status: authRes.status, code, consoleUrl: location });
 
-  // 4. PKCE enforcement check — a non-matching verifier must be rejected with
+  // 5. PKCE enforcement check — a non-matching verifier must be rejected with
   // `invalid_grant`, and the rejection happens before approval (the verifier is
   // checked on every /token poll). If this mints or pends, PKCE isn't enforced.
-  const bad = await postToken(code, 'this-verifier-does-not-match-the-challenge');
+  const bad = await postToken(code, 'a'.repeat(43));
   if (bad.body.error !== 'invalid_grant') {
     throw new Error(
       `PKCE not enforced: bad verifier expected invalid_grant, got ${JSON.stringify(bad.body)}`
@@ -102,7 +135,7 @@ async function main() {
   }
   log('pkce-enforced', { status: bad.status, error: bad.body.error });
 
-  // 5. Approve (manual) + 6. poll /token with the MATCHING verifier for the
+  // 6. Approve (manual) + 7. poll /token with the MATCHING verifier for the
   // minted key. We only call the MCP's own token endpoint — it polls the backend
   // server-side and returns the minted key once the request is APPROVED.
   console.log('\n[approve] Open and approve in your browser:\n' + location);
@@ -128,7 +161,7 @@ async function main() {
     note: 'minted Runpod API key — check the dashboard for its name',
   });
 
-  // 6. Connect to the MCP with the minted key and call a tool
+  // 8. Connect to the MCP with the minted key and call a tool
   const client = new Client({ name: 'oauth-e2e', version: '1.0.0' });
   const transport = new StreamableHTTPClientTransport(new URL(base), {
     requestInit: { headers: { Authorization: `Bearer ${key}` } },

--- a/src/oauth/pkce.ts
+++ b/src/oauth/pkce.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * True for a loopback host (localhost / 127.0.0.1 / ::1), ignoring IPv6 brackets.
+ * Loopback is the native-app redirect case that PKCE (RFC 7636) is designed for.
+ */
+export function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.replace(/^\[|\]$/g, '');
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
+/** True when `redirectUri` parses and points at a loopback host. */
+export function isLoopbackRedirect(redirectUri: string | null): boolean {
+  if (!redirectUri) return false;
+  try {
+    return isLoopbackHost(new URL(redirectUri).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * S256 transform: base64url(SHA-256(verifier)), unpadded — RFC 7636 §4.2.
+ */
+export function s256(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+/**
+ * Verify a PKCE (RFC 7636) code_verifier against the code_challenge stored on the
+ * flash auth request. Returns null when the token exchange may proceed, or an
+ * OAuth error_description string when it must be rejected (invalid_grant).
+ *
+ * Policy:
+ * - We advertise only S256, so a stored non-S256 method (e.g. `plain`) is rejected.
+ * - When a challenge was stored, a code_verifier is mandatory and must match.
+ * - Loopback redirect URIs (native apps — the interception case PKCE is designed
+ *   for) MUST use PKCE; a loopback flow with no stored challenge is rejected.
+ *   Hosted exact-match redirects may still use the legacy non-PKCE flow.
+ */
+export function verifyPkce(input: {
+  codeChallenge?: string | null;
+  codeChallengeMethod?: string | null;
+  codeVerifier?: string | null;
+  redirectUri: string | null;
+}): string | null {
+  const { codeChallenge, codeChallengeMethod, codeVerifier, redirectUri } = input;
+
+  if (!codeChallenge) {
+    if (isLoopbackRedirect(redirectUri)) {
+      return 'PKCE is required for loopback redirect URIs.';
+    }
+    return null; // legacy hosted (exact-match) flow, no PKCE
+  }
+
+  if (codeChallengeMethod && codeChallengeMethod !== 'S256') {
+    return `Unsupported code_challenge_method '${codeChallengeMethod}'; only S256 is supported.`;
+  }
+  if (!codeVerifier) {
+    return 'code_verifier is required.';
+  }
+  if (s256(codeVerifier) !== codeChallenge) {
+    return 'PKCE verification failed.';
+  }
+  return null;
+}

--- a/src/oauth/pkce.ts
+++ b/src/oauth/pkce.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 
 /**
  * True for a loopback host (localhost / 127.0.0.1 / ::1), ignoring IPv6 brackets.
@@ -24,6 +24,18 @@ export function isLoopbackRedirect(redirectUri: string | null): boolean {
  */
 export function s256(verifier: string): string {
   return createHash('sha256').update(verifier).digest('base64url');
+}
+
+/**
+ * Constant-time string compare. Returns false immediately on a length mismatch
+ * (timingSafeEqual throws on unequal-length buffers), else compares without an
+ * early-exit that could leak how many leading chars matched.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
 }
 
 /**
@@ -59,7 +71,7 @@ export function verifyPkce(input: {
   if (!codeVerifier) {
     return 'code_verifier is required.';
   }
-  if (s256(codeVerifier) !== codeChallenge) {
+  if (!safeEqual(s256(codeVerifier), codeChallenge)) {
     return 'PKCE verification failed.';
   }
   return null;

--- a/src/oauth/pkce.ts
+++ b/src/oauth/pkce.ts
@@ -12,6 +12,14 @@ export function isLoopbackHost(hostname: string): boolean {
 const S256_CHALLENGE = /^[A-Za-z0-9_-]{43}$/;
 const CODE_VERIFIER = /^[A-Za-z0-9._~-]{43,128}$/;
 
+type PkceAuthorizationResult =
+  | { ok: true; codeChallenge: string }
+  | { ok: false; error: string };
+
+type PkceVerifierResult =
+  | { ok: true; codeVerifier: string }
+  | { ok: false; error: string };
+
 /**
  * S256 transform: base64url(SHA-256(verifier)), unpadded — RFC 7636 §4.2.
  */
@@ -38,19 +46,38 @@ function safeEqual(a: string, b: string): boolean {
 export function validatePkceAuthorization(input: {
   codeChallenge?: string | null;
   codeChallengeMethod?: string | null;
-}): string | null {
+}): PkceAuthorizationResult {
   const { codeChallenge, codeChallengeMethod } = input;
 
   if (!codeChallenge) {
-    return 'code_challenge is required.';
+    return { ok: false, error: 'code_challenge is required.' };
   }
   if (codeChallengeMethod !== 'S256') {
-    return 'code_challenge_method must be S256.';
+    return { ok: false, error: 'code_challenge_method must be S256.' };
   }
   if (!S256_CHALLENGE.test(codeChallenge)) {
-    return 'code_challenge must be a 43-character base64url S256 value.';
+    return {
+      ok: false,
+      error: 'code_challenge must be a 43-character base64url S256 value.',
+    };
   }
-  return null;
+  return { ok: true, codeChallenge };
+}
+
+/** Validate the client-owned verifier before reading or consuming a code. */
+export function validatePkceVerifier(
+  codeVerifier?: string | null
+): PkceVerifierResult {
+  if (!codeVerifier) {
+    return { ok: false, error: 'code_verifier is required.' };
+  }
+  if (!CODE_VERIFIER.test(codeVerifier)) {
+    return {
+      ok: false,
+      error: 'code_verifier must be 43 to 128 unreserved characters.',
+    };
+  }
+  return { ok: true, codeVerifier };
 }
 
 /**
@@ -78,13 +105,10 @@ export function verifyPkce(input: {
   if (!S256_CHALLENGE.test(codeChallenge)) {
     return 'Stored code_challenge is not a valid S256 value.';
   }
-  if (!codeVerifier) {
-    return 'code_verifier is required.';
-  }
-  if (!CODE_VERIFIER.test(codeVerifier)) {
-    return 'code_verifier must be 43 to 128 unreserved characters.';
-  }
-  if (!safeEqual(s256(codeVerifier), codeChallenge)) {
+  const verifier = validatePkceVerifier(codeVerifier);
+  if (!verifier.ok) return verifier.error;
+
+  if (!safeEqual(s256(verifier.codeVerifier), codeChallenge)) {
     return 'PKCE verification failed.';
   }
   return null;

--- a/src/oauth/pkce.ts
+++ b/src/oauth/pkce.ts
@@ -9,15 +9,8 @@ export function isLoopbackHost(hostname: string): boolean {
   return h === 'localhost' || h === '127.0.0.1' || h === '::1';
 }
 
-/** True when `redirectUri` parses and points at a loopback host. */
-export function isLoopbackRedirect(redirectUri: string | null): boolean {
-  if (!redirectUri) return false;
-  try {
-    return isLoopbackHost(new URL(redirectUri).hostname);
-  } catch {
-    return false;
-  }
-}
+const S256_CHALLENGE = /^[A-Za-z0-9_-]{43}$/;
+const CODE_VERIFIER = /^[A-Za-z0-9._~-]{43,128}$/;
 
 /**
  * S256 transform: base64url(SHA-256(verifier)), unpadded — RFC 7636 §4.2.
@@ -39,37 +32,57 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 /**
+ * Validate PKCE parameters before issuing an authorization code. This server
+ * advertises only S256 and requires it for every hosted OAuth flow.
+ */
+export function validatePkceAuthorization(input: {
+  codeChallenge?: string | null;
+  codeChallengeMethod?: string | null;
+}): string | null {
+  const { codeChallenge, codeChallengeMethod } = input;
+
+  if (!codeChallenge) {
+    return 'code_challenge is required.';
+  }
+  if (codeChallengeMethod !== 'S256') {
+    return 'code_challenge_method must be S256.';
+  }
+  if (!S256_CHALLENGE.test(codeChallenge)) {
+    return 'code_challenge must be a 43-character base64url S256 value.';
+  }
+  return null;
+}
+
+/**
  * Verify a PKCE (RFC 7636) code_verifier against the code_challenge stored on the
  * flash auth request. Returns null when the token exchange may proceed, or an
  * OAuth error_description string when it must be rejected (invalid_grant).
  *
  * Policy:
- * - We advertise only S256, so a stored non-S256 method (e.g. `plain`) is rejected.
- * - When a challenge was stored, a code_verifier is mandatory and must match.
- * - Loopback redirect URIs (native apps — the interception case PKCE is designed
- *   for) MUST use PKCE; a loopback flow with no stored challenge is rejected.
- *   Hosted exact-match redirects may still use the legacy non-PKCE flow.
+ * - Every authorization code must have a valid S256 challenge and method.
+ * - A code_verifier is mandatory, must follow RFC 7636 syntax, and must match.
  */
 export function verifyPkce(input: {
   codeChallenge?: string | null;
   codeChallengeMethod?: string | null;
   codeVerifier?: string | null;
-  redirectUri: string | null;
 }): string | null {
-  const { codeChallenge, codeChallengeMethod, codeVerifier, redirectUri } = input;
+  const { codeChallenge, codeChallengeMethod, codeVerifier } = input;
 
   if (!codeChallenge) {
-    if (isLoopbackRedirect(redirectUri)) {
-      return 'PKCE is required for loopback redirect URIs.';
-    }
-    return null; // legacy hosted (exact-match) flow, no PKCE
+    return 'PKCE code_challenge is missing for this authorization code.';
   }
-
-  if (codeChallengeMethod && codeChallengeMethod !== 'S256') {
-    return `Unsupported code_challenge_method '${codeChallengeMethod}'; only S256 is supported.`;
+  if (codeChallengeMethod !== 'S256') {
+    return 'Stored code_challenge_method must be S256.';
+  }
+  if (!S256_CHALLENGE.test(codeChallenge)) {
+    return 'Stored code_challenge is not a valid S256 value.';
   }
   if (!codeVerifier) {
     return 'code_verifier is required.';
+  }
+  if (!CODE_VERIFIER.test(codeVerifier)) {
+    return 'code_verifier must be 43 to 128 unreserved characters.';
   }
   if (!safeEqual(s256(codeVerifier), codeChallenge)) {
     return 'PKCE verification failed.';

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { after, before, beforeEach, describe, it } from 'node:test';
+
+import handler from '../api/index.js';
+
+type JsonObject = Record<string, unknown>;
+
+class FakeResponse {
+  statusCode = 200;
+  body: JsonObject | undefined;
+  location: string | undefined;
+  headers = new Map<string, unknown>();
+
+  setHeader(name: string, value: unknown) {
+    this.headers.set(name.toLowerCase(), value);
+  }
+
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(body: JsonObject) {
+    this.body = body;
+    return this;
+  }
+
+  redirect(code: number, location: string) {
+    this.statusCode = code;
+    this.location = location;
+    return this;
+  }
+
+  end() {
+    return this;
+  }
+}
+
+const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+const HOSTED_REDIRECT = 'https://claude.ai/api/mcp/auth_callback';
+const LOOPBACK_REDIRECT = 'http://127.0.0.1:8765/callback';
+
+const originalGraphqlUrl = process.env.RUNPOD_GRAPHQL_URL;
+const originalConsoleBaseUrl = process.env.CONSOLE_BASE_URL;
+const originalApiKeyName = process.env.RUNPOD_API_KEY_NAME;
+
+let backend: http.Server;
+let backendRequests: string[] = [];
+let flashStatus: JsonObject;
+
+before(async () => {
+  backend = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    req.on('end', () => {
+      const payload = JSON.parse(Buffer.concat(chunks).toString()) as {
+        query: string;
+      };
+      backendRequests.push(payload.query);
+      res.setHeader('content-type', 'application/json');
+      if (payload.query.includes('createFlashAuthRequest')) {
+        res.end(
+          JSON.stringify({ data: { createFlashAuthRequest: { id: 'code-1' } } })
+        );
+        return;
+      }
+      res.end(
+        JSON.stringify({ data: { flashAuthRequestStatus: flashStatus } })
+      );
+    });
+  });
+
+  await new Promise<void>((resolve) => backend.listen(0, '127.0.0.1', resolve));
+  const address = backend.address();
+  assert(address && typeof address === 'object');
+  process.env.RUNPOD_GRAPHQL_URL = `http://127.0.0.1:${address.port}/graphql`;
+  process.env.CONSOLE_BASE_URL = 'https://console.example.test';
+  process.env.RUNPOD_API_KEY_NAME = '';
+});
+
+beforeEach(() => {
+  backendRequests = [];
+  flashStatus = {
+    id: 'code-1',
+    status: 'APPROVED',
+    apiKey: 'rp_test_secret',
+    codeChallenge: CHALLENGE,
+    codeChallengeMethod: 'S256',
+  };
+});
+
+after(async () => {
+  if (originalGraphqlUrl === undefined) delete process.env.RUNPOD_GRAPHQL_URL;
+  else process.env.RUNPOD_GRAPHQL_URL = originalGraphqlUrl;
+  if (originalConsoleBaseUrl === undefined) delete process.env.CONSOLE_BASE_URL;
+  else process.env.CONSOLE_BASE_URL = originalConsoleBaseUrl;
+  if (originalApiKeyName === undefined) delete process.env.RUNPOD_API_KEY_NAME;
+  else process.env.RUNPOD_API_KEY_NAME = originalApiKeyName;
+
+  await new Promise<void>((resolve, reject) =>
+    backend.close((error) => (error ? reject(error) : resolve()))
+  );
+});
+
+async function request(method: string, url: string, body?: string) {
+  const req = {
+    method,
+    url,
+    body,
+    headers: { host: 'mcp.example.test' },
+  };
+  const res = new FakeResponse();
+  await handler(req as never, res as never);
+  return res;
+}
+
+async function authorize(
+  redirectUri: string,
+  codeChallenge?: string,
+  codeChallengeMethod?: string
+) {
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: 'test-client',
+    redirect_uri: redirectUri,
+  });
+  if (codeChallenge !== undefined) {
+    params.set('code_challenge', codeChallenge);
+  }
+  if (codeChallengeMethod !== undefined) {
+    params.set('code_challenge_method', codeChallengeMethod);
+  }
+  return request('GET', `/authorize?${params.toString()}`);
+}
+
+async function token(codeVerifier?: string) {
+  const params = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: 'code-1',
+    redirect_uri: HOSTED_REDIRECT,
+  });
+  if (codeVerifier !== undefined) {
+    params.set('code_verifier', codeVerifier);
+  }
+  return request('POST', '/token', params.toString());
+}
+
+describe('OAuth PKCE endpoints', () => {
+  it('rejects missing PKCE for both hosted and loopback redirects', async () => {
+    for (const redirectUri of [HOSTED_REDIRECT, LOOPBACK_REDIRECT]) {
+      const res = await authorize(redirectUri);
+      assert.equal(res.statusCode, 400);
+      assert.deepEqual(res.body, {
+        error: 'invalid_request',
+        error_description: 'code_challenge is required.',
+      });
+    }
+    assert.equal(backendRequests.length, 0);
+  });
+
+  it('rejects missing, plain, and malformed challenge methods before issuing a code', async () => {
+    const missing = await authorize(HOSTED_REDIRECT, CHALLENGE);
+    assert.equal(missing.statusCode, 400);
+
+    const plain = await authorize(HOSTED_REDIRECT, VERIFIER, 'plain');
+    assert.equal(plain.statusCode, 400);
+
+    const malformed = await authorize(HOSTED_REDIRECT, `${CHALLENGE}=`, 'S256');
+    assert.equal(malformed.statusCode, 400);
+    assert.equal(backendRequests.length, 0);
+  });
+
+  it('persists valid S256 parameters and starts authorization', async () => {
+    const res = await authorize(HOSTED_REDIRECT, CHALLENGE, 'S256');
+    assert.equal(res.statusCode, 302);
+    assert.match(res.location ?? '', /^https:\/\/console\.example\.test\//);
+    assert.equal(backendRequests.length, 1);
+    assert.match(
+      backendRequests[0],
+      new RegExp(`codeChallenge: "${CHALLENGE}"`)
+    );
+    assert.match(backendRequests[0], /codeChallengeMethod: "S256"/);
+  });
+
+  it('fails closed when an authorization code has no stored PKCE state', async () => {
+    flashStatus.codeChallenge = null;
+    flashStatus.codeChallengeMethod = null;
+
+    const res = await token();
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, {
+      error: 'invalid_grant',
+      error_description:
+        'PKCE code_challenge is missing for this authorization code.',
+    });
+  });
+
+  it('rejects a missing or wrong verifier', async () => {
+    const missing = await token();
+    assert.equal(missing.statusCode, 400);
+    assert.equal(missing.body?.error, 'invalid_grant');
+
+    const wrong = await token('a'.repeat(43));
+    assert.equal(wrong.statusCode, 400);
+    assert.equal(wrong.body?.error_description, 'PKCE verification failed.');
+  });
+
+  it('returns the API key only for a matching verifier', async () => {
+    const res = await token(VERIFIER);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, {
+      access_token: 'rp_test_secret',
+      token_type: 'Bearer',
+    });
+  });
+});

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -188,7 +188,7 @@ describe('OAuth PKCE endpoints', () => {
     flashStatus.codeChallenge = null;
     flashStatus.codeChallengeMethod = null;
 
-    const res = await token();
+    const res = await token(VERIFIER);
     assert.equal(res.statusCode, 400);
     assert.deepEqual(res.body, {
       error: 'invalid_grant',
@@ -197,14 +197,24 @@ describe('OAuth PKCE endpoints', () => {
     });
   });
 
-  it('rejects a missing or wrong verifier', async () => {
+  it('rejects malformed verifiers without reading or consuming the code', async () => {
     const missing = await token();
     assert.equal(missing.statusCode, 400);
     assert.equal(missing.body?.error, 'invalid_grant');
+    assert.equal(backendRequests.length, 0);
+
+    const malformed = await token('too-short');
+    assert.equal(malformed.statusCode, 400);
+    assert.equal(
+      malformed.body?.error_description,
+      'code_verifier must be 43 to 128 unreserved characters.'
+    );
+    assert.equal(backendRequests.length, 0);
 
     const wrong = await token('a'.repeat(43));
     assert.equal(wrong.statusCode, 400);
     assert.equal(wrong.body?.error_description, 'PKCE verification failed.');
+    assert.equal(backendRequests.length, 1);
   });
 
   it('returns the API key only for a matching verifier', async () => {

--- a/tests/pkce.test.ts
+++ b/tests/pkce.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { s256, verifyPkce } from '../src/oauth/pkce.js';
+
+// RFC 7636 Appendix B canonical test vector.
+const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+const HOSTED = 'https://claude.ai/api/mcp/auth_callback';
+const LOOPBACK = 'http://127.0.0.1:53219/callback';
+
+describe('s256', () => {
+  it('reproduces the RFC 7636 Appendix B vector (unpadded base64url)', () => {
+    assert.equal(s256(VERIFIER), CHALLENGE);
+  });
+});
+
+describe('verifyPkce', () => {
+  it('passes for a correct verifier (S256)', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: CHALLENGE,
+        codeChallengeMethod: 'S256',
+        codeVerifier: VERIFIER,
+        redirectUri: HOSTED,
+      }),
+      null
+    );
+  });
+
+  it('rejects a wrong verifier', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: CHALLENGE,
+        codeChallengeMethod: 'S256',
+        codeVerifier: 'not-the-verifier',
+        redirectUri: HOSTED,
+      }),
+      'PKCE verification failed.'
+    );
+  });
+
+  it('rejects a missing verifier when a challenge was stored', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: CHALLENGE,
+        codeChallengeMethod: 'S256',
+        codeVerifier: null,
+        redirectUri: HOSTED,
+      }),
+      'code_verifier is required.'
+    );
+  });
+
+  it('rejects the plain method (we advertise only S256)', () => {
+    const err = verifyPkce({
+      codeChallenge: VERIFIER, // plain challenge == verifier
+      codeChallengeMethod: 'plain',
+      codeVerifier: VERIFIER,
+      redirectUri: HOSTED,
+    });
+    assert.match(String(err), /only S256 is supported/);
+  });
+
+  it('allows a hosted exact-match redirect with no challenge (legacy flow)', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: null,
+        codeChallengeMethod: null,
+        codeVerifier: null,
+        redirectUri: HOSTED,
+      }),
+      null
+    );
+  });
+
+  it('requires PKCE for a loopback redirect with no challenge', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: null,
+        codeChallengeMethod: null,
+        codeVerifier: null,
+        redirectUri: LOOPBACK,
+      }),
+      'PKCE is required for loopback redirect URIs.'
+    );
+  });
+
+  it('passes a loopback redirect when PKCE is present and correct', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: CHALLENGE,
+        codeChallengeMethod: 'S256',
+        codeVerifier: VERIFIER,
+        redirectUri: LOOPBACK,
+      }),
+      null
+    );
+  });
+});

--- a/tests/pkce.test.ts
+++ b/tests/pkce.test.ts
@@ -4,12 +4,20 @@ import assert from 'node:assert/strict';
 import {
   s256,
   validatePkceAuthorization,
+  validatePkceVerifier,
   verifyPkce,
 } from '../src/oauth/pkce.js';
 
 // RFC 7636 Appendix B canonical test vector.
 const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
 const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+function authorizationError(
+  input: Parameters<typeof validatePkceAuthorization>[0]
+): string | null {
+  const result = validatePkceAuthorization(input);
+  return result.ok ? null : result.error;
+}
 
 describe('s256', () => {
   it('reproduces the RFC 7636 Appendix B vector (unpadded base64url)', () => {
@@ -19,18 +27,18 @@ describe('s256', () => {
 
 describe('validatePkceAuthorization', () => {
   it('accepts a valid S256 challenge', () => {
-    assert.equal(
+    assert.deepEqual(
       validatePkceAuthorization({
         codeChallenge: CHALLENGE,
         codeChallengeMethod: 'S256',
       }),
-      null
+      { ok: true, codeChallenge: CHALLENGE }
     );
   });
 
   it('rejects a missing challenge', () => {
     assert.equal(
-      validatePkceAuthorization({
+      authorizationError({
         codeChallenge: null,
         codeChallengeMethod: null,
       }),
@@ -40,7 +48,7 @@ describe('validatePkceAuthorization', () => {
 
   it('rejects a missing method instead of treating it as S256', () => {
     assert.equal(
-      validatePkceAuthorization({
+      authorizationError({
         codeChallenge: CHALLENGE,
         codeChallengeMethod: null,
       }),
@@ -50,7 +58,7 @@ describe('validatePkceAuthorization', () => {
 
   it('rejects plain', () => {
     assert.equal(
-      validatePkceAuthorization({
+      authorizationError({
         codeChallenge: VERIFIER,
         codeChallengeMethod: 'plain',
       }),
@@ -60,12 +68,32 @@ describe('validatePkceAuthorization', () => {
 
   it('rejects a malformed S256 challenge', () => {
     assert.equal(
-      validatePkceAuthorization({
+      authorizationError({
         codeChallenge: `${CHALLENGE}=`,
         codeChallengeMethod: 'S256',
       }),
       'code_challenge must be a 43-character base64url S256 value.'
     );
+  });
+});
+
+describe('validatePkceVerifier', () => {
+  it('returns a normalized valid verifier', () => {
+    assert.deepEqual(validatePkceVerifier(VERIFIER), {
+      ok: true,
+      codeVerifier: VERIFIER,
+    });
+  });
+
+  it('rejects missing and malformed verifiers', () => {
+    assert.deepEqual(validatePkceVerifier(null), {
+      ok: false,
+      error: 'code_verifier is required.',
+    });
+    assert.deepEqual(validatePkceVerifier('too-short'), {
+      ok: false,
+      error: 'code_verifier must be 43 to 128 unreserved characters.',
+    });
   });
 });
 

--- a/tests/pkce.test.ts
+++ b/tests/pkce.test.ts
@@ -1,18 +1,71 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { s256, verifyPkce } from '../src/oauth/pkce.js';
+import {
+  s256,
+  validatePkceAuthorization,
+  verifyPkce,
+} from '../src/oauth/pkce.js';
 
 // RFC 7636 Appendix B canonical test vector.
 const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
 const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 
-const HOSTED = 'https://claude.ai/api/mcp/auth_callback';
-const LOOPBACK = 'http://127.0.0.1:53219/callback';
-
 describe('s256', () => {
   it('reproduces the RFC 7636 Appendix B vector (unpadded base64url)', () => {
     assert.equal(s256(VERIFIER), CHALLENGE);
+  });
+});
+
+describe('validatePkceAuthorization', () => {
+  it('accepts a valid S256 challenge', () => {
+    assert.equal(
+      validatePkceAuthorization({
+        codeChallenge: CHALLENGE,
+        codeChallengeMethod: 'S256',
+      }),
+      null
+    );
+  });
+
+  it('rejects a missing challenge', () => {
+    assert.equal(
+      validatePkceAuthorization({
+        codeChallenge: null,
+        codeChallengeMethod: null,
+      }),
+      'code_challenge is required.'
+    );
+  });
+
+  it('rejects a missing method instead of treating it as S256', () => {
+    assert.equal(
+      validatePkceAuthorization({
+        codeChallenge: CHALLENGE,
+        codeChallengeMethod: null,
+      }),
+      'code_challenge_method must be S256.'
+    );
+  });
+
+  it('rejects plain', () => {
+    assert.equal(
+      validatePkceAuthorization({
+        codeChallenge: VERIFIER,
+        codeChallengeMethod: 'plain',
+      }),
+      'code_challenge_method must be S256.'
+    );
+  });
+
+  it('rejects a malformed S256 challenge', () => {
+    assert.equal(
+      validatePkceAuthorization({
+        codeChallenge: `${CHALLENGE}=`,
+        codeChallengeMethod: 'S256',
+      }),
+      'code_challenge must be a 43-character base64url S256 value.'
+    );
   });
 });
 
@@ -23,7 +76,6 @@ describe('verifyPkce', () => {
         codeChallenge: CHALLENGE,
         codeChallengeMethod: 'S256',
         codeVerifier: VERIFIER,
-        redirectUri: HOSTED,
       }),
       null
     );
@@ -34,8 +86,7 @@ describe('verifyPkce', () => {
       verifyPkce({
         codeChallenge: CHALLENGE,
         codeChallengeMethod: 'S256',
-        codeVerifier: 'not-the-verifier',
-        redirectUri: HOSTED,
+        codeVerifier: 'a'.repeat(43),
       }),
       'PKCE verification failed.'
     );
@@ -47,55 +98,54 @@ describe('verifyPkce', () => {
         codeChallenge: CHALLENGE,
         codeChallengeMethod: 'S256',
         codeVerifier: null,
-        redirectUri: HOSTED,
       }),
       'code_verifier is required.'
     );
   });
 
-  it('rejects the plain method (we advertise only S256)', () => {
-    const err = verifyPkce({
-      codeChallenge: VERIFIER, // plain challenge == verifier
-      codeChallengeMethod: 'plain',
-      codeVerifier: VERIFIER,
-      redirectUri: HOSTED,
-    });
-    assert.match(String(err), /only S256 is supported/);
-  });
-
-  it('allows a hosted exact-match redirect with no challenge (legacy flow)', () => {
-    assert.equal(
-      verifyPkce({
-        codeChallenge: null,
-        codeChallengeMethod: null,
-        codeVerifier: null,
-        redirectUri: HOSTED,
-      }),
-      null
-    );
-  });
-
-  it('requires PKCE for a loopback redirect with no challenge', () => {
-    assert.equal(
-      verifyPkce({
-        codeChallenge: null,
-        codeChallengeMethod: null,
-        codeVerifier: null,
-        redirectUri: LOOPBACK,
-      }),
-      'PKCE is required for loopback redirect URIs.'
-    );
-  });
-
-  it('passes a loopback redirect when PKCE is present and correct', () => {
+  it('rejects a malformed verifier', () => {
     assert.equal(
       verifyPkce({
         codeChallenge: CHALLENGE,
         codeChallengeMethod: 'S256',
-        codeVerifier: VERIFIER,
-        redirectUri: LOOPBACK,
+        codeVerifier: 'too-short',
       }),
-      null
+      'code_verifier must be 43 to 128 unreserved characters.'
+    );
+  });
+
+  it('rejects an authorization code with no stored challenge', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: null,
+        codeChallengeMethod: 'S256',
+        codeVerifier: VERIFIER,
+      }),
+      'PKCE code_challenge is missing for this authorization code.'
+    );
+  });
+
+  it('rejects a missing or non-S256 stored method', () => {
+    for (const codeChallengeMethod of [null, 'plain']) {
+      assert.equal(
+        verifyPkce({
+          codeChallenge: CHALLENGE,
+          codeChallengeMethod,
+          codeVerifier: VERIFIER,
+        }),
+        'Stored code_challenge_method must be S256.'
+      );
+    }
+  });
+
+  it('rejects a malformed stored challenge', () => {
+    assert.equal(
+      verifyPkce({
+        codeChallenge: `${CHALLENGE}=`,
+        codeChallengeMethod: 'S256',
+        codeVerifier: VERIFIER,
+      }),
+      'Stored code_challenge is not a valid S256 value.'
     );
   });
 });


### PR DESCRIPTION
## What this PR does

Enforces PKCE (S256) for every hosted OAuth authorization flow.

- `/authorize` rejects missing, malformed, or non-S256 challenges with `invalid_request` before creating an authorization code
- valid `code_challenge` values are normalized and persisted with `code_challenge_method: S256` on the flash auth request
- `/token` rejects missing or malformed verifiers before reading or consuming backend authorization state
- `/token` requires valid stored S256 state plus a valid, matching `code_verifier` before returning the minted key
- missing/malformed/non-matching verifier or stored PKCE state → `invalid_grant`
- verifier comparison is constant-time (`crypto.timingSafeEqual`, length-guarded)
- there is no hosted or loopback legacy non-PKCE path

PKCE logic is isolated in `src/oauth/pkce.ts`. Unit tests cover the RFC 7636 vector, parameter syntax, and every policy branch; endpoint tests exercise `/authorize` and `/token` against a mock flash backend and prove malformed verifier requests make zero backend calls.

## Backend dependency — merged ✅

This depends on the DR-1398 backend fields, which are now on `main`:

| # | PR | Repo | Change |
|---|----|------|--------|
| 1 | runpod/RunPod#5015 | RunPod | **DB** — nullable `codeChallenge` / `codeChallengeMethod` on `FlashAuthRequest` |
| 2 | runpod/RunPod#5016 | RunPod | **Backend** — persist the challenge + expose it on `flashAuthRequestStatus` |
| 3 | this PR | runpod-mcp | **MCP** — validate S256 at `/authorize` and verify it at `/token` |

The backend remains a pure store: it persists and returns the public `code_challenge`; the `code_verifier` never reaches it. The SHA-256 verification happens here, at `/token`.

No additional database fields or migrations are required.

## Notes

- Rebased onto the latest `main`.
- `README.md` is unchanged from `main`; this PR does not carry documentation changes.
- Field names match the backend schema exactly (`codeChallenge` / `codeChallengeMethod` on both `createFlashAuthRequest` and `flashAuthRequestStatus`).
- Existing authorization codes created without PKCE fail closed after this deployment.

## Test plan

- Full rebased suite: 428 pass / 0 fail / 8 opt-in live tests skipped
- Focused OAuth/PKCE endpoint and unit tests: 21 pass / 0 fail
- `tsc --noEmit` clean
- ESLint clean
- changed-file Prettier check clean
- production `tsup` build clean
- `scripts/oauth-e2e.ts` asserts missing PKCE, missing method, and `plain` are rejected before code issuance; a bad verifier returns `invalid_grant`; a matching verifier completes the flow
