### PR TITLE
fix(serverless): send the reshaped v2 /v2/serverless write schema

### DIFF
--- a/.changeset/serverless-typed-schema.md
+++ b/.changeset/serverless-typed-schema.md
@@ -1,0 +1,22 @@
+---
+'@runpod/mcp-server': minor
+---
+
+Send the reshaped v2 Serverless write schema, and support load-balancing endpoints.
+
+`/v2/serverless` changed its create/update contract: endpoint `type` (`QUEUE` or
+`LOAD_BALANCER`) is now required on create, the autoscaling object moved from a flat
+`{type, value, idleTimeout}` to a per-scaler `{type, queueDelay}` / `{type, requestCount}`,
+and `idleTimeout` moved under `workers`. `create-endpoint` and `update-endpoint` now emit
+that shape; previously they sent the older one and were rejected with a `422`.
+
+`create-endpoint` gains `endpointType` for queue-based (default) versus load-balancing
+request routing. `scalerType` defaults per endpoint type, `scalerValue` defaults to `4`, and
+passing `scalerValue` alone on `update-endpoint` keeps the endpoint's current scaler, so
+existing calls keep working unchanged. Responses carry `type` and `requestUrls`, and
+`get-endpoint` / `list-endpoints` now point at `requestUrls` as the source for an endpoint's
+URLs.
+
+**This requires a Runpod API host serving the new schema.** Against a host still on the older
+one, endpoint create/update return a `422` naming `queueDelay`/`requestCount`/`idleTimeout` as
+not allowed. `RUNPOD_REST_VERSION=v1` remains available for the legacy template-based model.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,19 @@ Notes:
 
 > **Migration note — `create-endpoint` / `update-endpoint` changed in v2.** Serverless endpoints now use an **inline config** instead of a `templateId`: `create-endpoint` requires `imageName` + `gpuPoolIds` (GPU **pool** names from `list-gpu-types`, e.g. `AMPERE_80`), plus optional `workersMin`/`workersMax`, scaler settings, `containerDiskInGb`, `env`, `flashboot`, etc. A pre-existing `{ templateId }` call now returns a clean `400`. Switch to the inline fields, or set `RUNPOD_REST_VERSION=v1` to keep the template-based model.
 
+## Serverless endpoint types and autoscaling
+
+`create-endpoint` takes an `endpointType`:
+
+- **`QUEUE`** (default) — jobs go through the managed queue. `run`, `runsync`, `status`, `stream`, `cancel`, `retry`, `purge-queue` and `health` all apply.
+- **`LOAD_BALANCER`** — HTTP requests go straight to worker-defined paths. There is no queue, so these endpoints scale on `REQUEST_COUNT` only; `QUEUE_DELAY` is rejected.
+
+An endpoint's type is fixed at creation — `update-endpoint` cannot change it. Read the URLs to call an endpoint with from `requestUrls` on the `get-endpoint` / `list-endpoints` reply rather than constructing them: a queue endpoint returns the full job-API set, a load-balancing one returns its base and health URLs.
+
+Autoscaling is set with `scalerType` (`QUEUE_DELAY` = seconds a request waits in the queue, min `0.5`; `REQUEST_COUNT` = in-flight requests per worker, integer min `1`), `scalerValue` (default `4`), and `idleTimeout` (seconds, `1`–`3600`). `scalerType` defaults to `QUEUE_DELAY` for queue endpoints and `REQUEST_COUNT` for load-balancing ones. `idleTimeout` does not apply to a queue endpoint scaling on `REQUEST_COUNT`.
+
+> **Requires a host serving the reshaped `/v2/serverless` write schema.** These tools send endpoint `type` on create, a per-scaler `scaling` object (`{type, queueDelay}` / `{type, requestCount}`), and `idleTimeout` under `workers`. A host still on the older flat shape rejects that with a `422` naming `queueDelay`/`requestCount`/`idleTimeout` as not allowed. If you hit that, point `RUNPOD_REST_V2_API_URL` at a host with the new schema, or set `RUNPOD_REST_VERSION=v1` for the legacy template-based model.
+
 ## Private image pull: credentials vs ECR delegation
 
 Two ways to let Runpod pull a private image, and they are not interchangeable:

--- a/src/_shared/mappers.ts
+++ b/src/_shared/mappers.ts
@@ -12,13 +12,11 @@
 // template `category` became optional with a documented server-side `NVIDIA`
 // default, so the mapper no longer forces a value.
 //
-// ⚠️ The vendored spec is the DEV spec (see scripts/fetch-v2-spec.ts), and dev has
-// moved ahead of production on `/v2/serverless` writes: `type` became required on
-// create, `scaling` became a union keyed on it, and `idleTimeout` moved into
-// `workers`. mapEndpointCreateToV2/...UpdateToV2 below still emit the shape
-// production accepts today, so they do NOT match the vendored spec for endpoints.
-// That is tracked separately; the spec-parity gate cannot see it, since it checks
-// operationId-to-tool coverage and never validates a request body against a schema.
+// `/v2/serverless` writes now match the vendored spec: `type` is a create field,
+// `scaling` is a union keyed on it, and `idleTimeout` sits under `workers`. Note the
+// spec-parity gate cannot police this — it checks operationId-to-tool coverage and
+// never validates a request body against a schema, so the mapper tests in
+// tests/mappers.test.ts are the only guard on the emitted shape.
 
 // v1 params accepted by the create-pod / update-pod tool schemas (the fields the
 // mapper knows how to translate). Unknown keys are intentionally dropped.
@@ -142,18 +140,21 @@ export function mapPodUpdateToV2(params: V1PodParams): Record<string, unknown> {
 // helper emits `mounts` (a pod/template concept), which the endpoint schema
 // rejects; endpoints attach storage via `networkVolumes` instead.
 //
-// Required by v2 CreateEndpointRequest: `name` and `gpu` (with `gpu.pools`
-// minItems 1). The create-endpoint handler guards those before calling, so a
-// missing field yields a clean 400 rather than a raw 422 from the API.
+// Required by v2 CreateEndpointRequest: `name`, `image`, `gpu` (with `gpu.pools`
+// minItems 1), `type` and `scaling`. The create-endpoint handler guards the first
+// three before calling, so a missing field yields a clean 400 rather than a raw
+// 422 from the API; the last two are always emitted, defaulted below.
+
 interface V2EndpointParams {
   name?: string;
   imageName?: string;
   args?: string;
+  endpointType?: EndpointType;
   gpuPoolIds?: string[];
   gpuCount?: number;
   workersMin?: number;
   workersMax?: number;
-  scalerType?: 'QUEUE_DELAY' | 'REQUEST_COUNT';
+  scalerType?: ScalerType;
   scalerValue?: number;
   idleTimeout?: number;
   dataCenterIds?: string[];
@@ -166,13 +167,35 @@ interface V2EndpointParams {
   containerRegistryAuthId?: string;
 }
 
-// Emit a nested object only when at least one field is set, else undefined (so
-// compact drops it). Prevents sending an empty `workers: {}` / `scaling: {}`.
-function nestedOrUndefined(
-  obj: Record<string, unknown>
-): Record<string, unknown> | undefined {
-  const c = compact(obj);
-  return Object.keys(c).length ? c : undefined;
+type EndpointType = 'QUEUE' | 'LOAD_BALANCER';
+type ScalerType = 'QUEUE_DELAY' | 'REQUEST_COUNT';
+
+// `type` and `scaling` are required on create, so something must be sent. These are
+// what the API used to apply server-side, so a caller that passes neither keeps
+// getting the endpoint it always got.
+//
+// DEFAULT_ENDPOINT_TYPE is create-only — update never sends `type`. DEFAULT_SCALER_VALUE
+// applies on BOTH: the scaling union requires a target next to its discriminator, so
+// `scalerType` alone still has to carry a value.
+const DEFAULT_ENDPOINT_TYPE: EndpointType = 'QUEUE';
+const DEFAULT_SCALER_VALUE = 4;
+
+// The scaler each endpoint type uses when the caller does not name one. Queue
+// endpoints may use either signal; load-balancing endpoints have no queue, so
+// REQUEST_COUNT is their only legal choice.
+function defaultScalerType(endpointType: EndpointType): ScalerType {
+  return endpointType === 'LOAD_BALANCER' ? 'REQUEST_COUNT' : 'QUEUE_DELAY';
+}
+
+// `scaling` is a union discriminated on `type`, with the target carried under a
+// per-variant key rather than a shared `value`.
+function endpointScaling(
+  scalerType: ScalerType,
+  value: number
+): Record<string, unknown> {
+  return scalerType === 'REQUEST_COUNT'
+    ? { type: 'REQUEST_COUNT', requestCount: value }
+    : { type: 'QUEUE_DELAY', queueDelay: value };
 }
 
 // gpu requires `pools` (minItems 1) — return undefined when no pools so the
@@ -185,7 +208,22 @@ function endpointGpuConfig(
   return compact({ pools, count });
 }
 
-function mapEndpointToV2(params: V2EndpointParams): Record<string, unknown> {
+// `workers` absorbed `idleTimeout` from `scaling`. Returns undefined when the caller
+// set none of the three, so we never send an empty `workers: {}`.
+function endpointWorkers(
+  params: V2EndpointParams
+): Record<string, unknown> | undefined {
+  const workers = compact({
+    min: params.workersMin,
+    max: params.workersMax,
+    idleTimeout: params.idleTimeout,
+  });
+  return Object.keys(workers).length ? workers : undefined;
+}
+
+// The half of the body shared by create and update: container config, compute,
+// placement and workers. Only `type` and `scaling` differ between the two.
+function endpointCommonToV2(params: V2EndpointParams): Record<string, unknown> {
   return compact({
     name: params.name,
     image: params.imageName,
@@ -195,15 +233,7 @@ function mapEndpointToV2(params: V2EndpointParams): Record<string, unknown> {
     env: params.env,
     registry: params.containerRegistryAuthId,
     gpu: endpointGpuConfig(params.gpuPoolIds, params.gpuCount),
-    workers: nestedOrUndefined({
-      min: params.workersMin,
-      max: params.workersMax,
-    }),
-    scaling: nestedOrUndefined({
-      type: params.scalerType,
-      value: params.scalerValue,
-      idleTimeout: params.idleTimeout,
-    }),
+    workers: endpointWorkers(params),
     dataCenterIds: params.dataCenterIds?.length
       ? params.dataCenterIds
       : undefined,
@@ -215,11 +245,39 @@ function mapEndpointToV2(params: V2EndpointParams): Record<string, unknown> {
   });
 }
 
-// Create and update share the same v2 body shape (Update just makes every field
-// optional — including `name`/`gpu`). Same mapper for both; the handler decides
-// which fields are required.
-export const mapEndpointCreateToV2 = mapEndpointToV2;
-export const mapEndpointUpdateToV2 = mapEndpointToV2;
+// CREATE. `type` and `scaling` are required, so both are always emitted.
+export function mapEndpointCreateToV2(
+  params: V2EndpointParams
+): Record<string, unknown> {
+  const endpointType = params.endpointType ?? DEFAULT_ENDPOINT_TYPE;
+  return compact({
+    ...endpointCommonToV2(params),
+    type: endpointType,
+    scaling: endpointScaling(
+      params.scalerType ?? defaultScalerType(endpointType),
+      params.scalerValue ?? DEFAULT_SCALER_VALUE
+    ),
+  });
+}
+
+// UPDATE. Only provided fields change, so nothing is defaulted into existence —
+// except the scaler target, which the union requires alongside its `type`
+// discriminator (so `scalerType` alone implies the default value). `type` is never
+// sent: the API rejects it on PATCH ("additional properties 'type' not allowed") —
+// an endpoint's routing model is fixed at creation.
+export function mapEndpointUpdateToV2(
+  params: V2EndpointParams
+): Record<string, unknown> {
+  return compact({
+    ...endpointCommonToV2(params),
+    scaling: params.scalerType
+      ? endpointScaling(
+          params.scalerType,
+          params.scalerValue ?? DEFAULT_SCALER_VALUE
+        )
+      : undefined,
+  });
+}
 
 // ---- Network volume: dataCenterId → dataCenter (only field change) ----
 interface V1NetworkVolumeCreate {

--- a/src/tools/endpoints.ts
+++ b/src/tools/endpoints.ts
@@ -12,6 +12,31 @@ import { logStreamParams, streamLogsReply } from './logs.js';
 // list/get/delete route through the adapter on both versions; create/update
 // branch on backend.version because the request model differs fundamentally.
 
+// Autoscaling bounds, mirroring the v2 spec so a bad value is a clean client-side
+// error instead of a server 422. `scalerValue` feeds two different union variants
+// with different bounds — QUEUE_DELAY takes a float >= 0.5, REQUEST_COUNT an
+// integer >= 1 — so the schema can only enforce the looser floor. The
+// REQUEST_COUNT half is checked per-call by scalerValueError() below, which needs
+// the resolved scaler type.
+const MIN_QUEUE_DELAY = 0.5;
+const MIN_REQUEST_COUNT = 1;
+const MIN_IDLE_TIMEOUT = 1;
+const MAX_IDLE_TIMEOUT = 3600;
+
+// Returns a message when scalerValue is illegal for the scaler it will be sent as,
+// or undefined when it is fine (including when either input is absent — the
+// mapper's defaults are always in range).
+function scalerValueError(
+  scalerType: 'QUEUE_DELAY' | 'REQUEST_COUNT' | undefined,
+  scalerValue: number | undefined
+): string | undefined {
+  if (scalerType !== 'REQUEST_COUNT' || scalerValue === undefined) return;
+  if (!Number.isInteger(scalerValue) || scalerValue < MIN_REQUEST_COUNT) {
+    return `REQUEST_COUNT scales on whole in-flight requests per worker, so scalerValue must be an integer >= ${MIN_REQUEST_COUNT} (got ${scalerValue}). For a fractional target use scalerType QUEUE_DELAY, which takes seconds >= ${MIN_QUEUE_DELAY}.`;
+  }
+  return;
+}
+
 export function registerEndpointTools(
   server: McpServer,
   rt: ToolRuntime
@@ -191,12 +216,16 @@ export function registerEndpointTools(
         ),
       scalerValue: z
         .number()
+        .min(MIN_QUEUE_DELAY)
         .optional()
         .describe(
           'Autoscaler target for the chosen scalerType — seconds of queue delay (min 0.5) or in-flight requests per worker (integer, min 1). Defaults to 4.'
         ),
       idleTimeout: z
         .number()
+        .int()
+        .min(MIN_IDLE_TIMEOUT)
+        .max(MAX_IDLE_TIMEOUT)
         .optional()
         .describe(
           'Idle timeout in seconds before scaling a worker down (1-3600). Does not apply to QUEUE endpoints scaling on REQUEST_COUNT.'
@@ -247,6 +276,19 @@ export function registerEndpointTools(
               'LOAD_BALANCER endpoints have no request queue, so they cannot scale on QUEUE_DELAY. Use scalerType REQUEST_COUNT (the default for this endpoint type), or create a QUEUE endpoint instead.',
             status: 400,
           });
+        }
+        // REQUEST_COUNT is the default scaler for a load balancer, so the value
+        // has to be checked against the scaler that will actually be sent, not
+        // just the one the caller named.
+        const scalerError = scalerValueError(
+          params.scalerType ??
+            (params.endpointType === 'LOAD_BALANCER'
+              ? 'REQUEST_COUNT'
+              : undefined),
+          params.scalerValue
+        );
+        if (scalerError) {
+          return jsonReply({ error: scalerError, status: 400 });
         }
         const body = backend.mapCreate(params) as Record<string, unknown>;
         const result = await callRestUrl(
@@ -309,6 +351,9 @@ export function registerEndpointTools(
         .describe('New maximum number of workers'),
       idleTimeout: z
         .number()
+        .int()
+        .min(MIN_IDLE_TIMEOUT)
+        .max(MAX_IDLE_TIMEOUT)
         .optional()
         .describe(
           'New idle timeout in seconds (1-3600). Does not apply to queue endpoints scaling on REQUEST_COUNT.'
@@ -321,6 +366,7 @@ export function registerEndpointTools(
         ),
       scalerValue: z
         .number()
+        .min(MIN_QUEUE_DELAY)
         .optional()
         .describe(
           "New autoscaler target — seconds of queue delay (min 0.5) or in-flight requests per worker (integer, min 1). Applies to the endpoint's current scalerType unless you also pass a new one."
@@ -383,6 +429,16 @@ export function registerEndpointTools(
           current?.scaling?.type === 'REQUEST_COUNT'
             ? 'REQUEST_COUNT'
             : 'QUEUE_DELAY';
+      }
+
+      // Checked against the resolved scaler, so `scalerValue` alone on an endpoint
+      // already scaling on REQUEST_COUNT is still held to the integer bound.
+      const scalerError = scalerValueError(
+        scalerType,
+        updateParams.scalerValue
+      );
+      if (scalerError) {
+        return jsonReply({ error: scalerError, status: 400 });
       }
 
       const body = backend.mapUpdate({

--- a/src/tools/endpoints.ts
+++ b/src/tools/endpoints.ts
@@ -22,7 +22,7 @@ export function registerEndpointTools(
   // v2 (GET /v2/serverless) declares none, so we only build the query under v1.
   server.tool(
     'list-endpoints',
-    'List your Serverless endpoints, optionally expanding template and worker details (v1 only). Paginated via limit/cursor.',
+    'List your Serverless endpoints, optionally expanding template and worker details (v1 only). Paginated via limit/cursor. On v2 each endpoint carries its request routing in `type` and the URLs to call it in `requestUrls`.',
     {
       ...listPaginationParams,
       includeTemplate: z
@@ -70,7 +70,7 @@ export function registerEndpointTools(
   // Get Endpoint Details
   server.tool(
     'get-endpoint',
-    'Get one Serverless endpoint by id, optionally expanding template and worker details (v1 only).',
+    'Get one Serverless endpoint by id, optionally expanding template and worker details (v1 only). On v2 the reply carries `type` (queue-based vs load-balancing routing) and `requestUrls` — the run/runsync/status/... URLs for a queue endpoint, or the base + health URLs for a load-balancing one. Read those rather than constructing endpoint URLs by hand.',
     {
       endpointId: z.string().describe('ID of the endpoint to retrieve'),
       includeTemplate: z
@@ -117,7 +117,7 @@ export function registerEndpointTools(
   //   v1: templateId-based.
   server.tool(
     'create-endpoint',
-    'Create a Serverless endpoint. On v2 (default), pass an inline config: imageName + gpuPoolIds (GPU pool names from list-gpu-types — the `pool` field, e.g. AMPERE_80/ADA_24) plus optional workers/scaling/disk/env. On v1, pass a templateId instead. Worker min/max set autoscaling bounds (min 0 = scale to zero).',
+    'Create a Serverless endpoint. On v2 (default), pass an inline config: imageName + gpuPoolIds (GPU pool names from list-gpu-types — the `pool` field, e.g. AMPERE_80/ADA_24) plus optional workers/scaling/disk/env. On v1, pass a templateId instead. Worker min/max set autoscaling bounds (min 0 = scale to zero). Use endpointType to pick queue-based (default) or load-balancing request routing; the response `requestUrls` carries the URLs to call the endpoint with.',
     {
       name: z.string().optional().describe('Name for the endpoint'),
       // --- v2 inline-config fields ---
@@ -125,6 +125,12 @@ export function registerEndpointTools(
         .string()
         .optional()
         .describe('Docker image (v2). Required on v2 instead of a templateId.'),
+      endpointType: z
+        .enum(['QUEUE', 'LOAD_BALANCER'])
+        .optional()
+        .describe(
+          'How requests reach the workers (v2). QUEUE (default) = submit jobs through the managed queue (run/runsync/status/...). LOAD_BALANCER = send HTTP requests straight to worker-defined paths, and forces scalerType REQUEST_COUNT. Fixed at creation — update-endpoint cannot change it.'
+        ),
       gpuPoolIds: z
         .array(z.string())
         .optional()
@@ -180,12 +186,21 @@ export function registerEndpointTools(
       scalerType: z
         .enum(['QUEUE_DELAY', 'REQUEST_COUNT'])
         .optional()
-        .describe('Autoscaler type'),
-      scalerValue: z.number().optional().describe('Autoscaler target value'),
+        .describe(
+          'Autoscaler signal. QUEUE_DELAY scales on how long requests wait in the queue (queue endpoints only); REQUEST_COUNT scales on in-flight requests per worker. Defaults to QUEUE_DELAY for QUEUE endpoints and REQUEST_COUNT for LOAD_BALANCER ones.'
+        ),
+      scalerValue: z
+        .number()
+        .optional()
+        .describe(
+          'Autoscaler target for the chosen scalerType — seconds of queue delay (min 0.5) or in-flight requests per worker (integer, min 1). Defaults to 4.'
+        ),
       idleTimeout: z
         .number()
         .optional()
-        .describe('Idle timeout in seconds before scaling a worker down'),
+        .describe(
+          'Idle timeout in seconds before scaling a worker down (1-3600). Does not apply to QUEUE endpoints scaling on REQUEST_COUNT.'
+        ),
       dataCenterIds: z
         .array(z.string())
         .optional()
@@ -217,6 +232,19 @@ export function registerEndpointTools(
           return jsonReply({
             error:
               'create-endpoint needs gpuPoolIds on v2 (GPU pool names from list-gpu-types — the `pool` field, e.g. ["AMPERE_80"]).',
+            status: 400,
+          });
+        }
+        // A load balancer has no request queue, so there is no queue delay to
+        // scale on. The API rejects this too, but catching it here costs a round
+        // trip less and names the reason directly.
+        if (
+          params.endpointType === 'LOAD_BALANCER' &&
+          params.scalerType === 'QUEUE_DELAY'
+        ) {
+          return jsonReply({
+            error:
+              'LOAD_BALANCER endpoints have no request queue, so they cannot scale on QUEUE_DELAY. Use scalerType REQUEST_COUNT (the default for this endpoint type), or create a QUEUE endpoint instead.',
             status: 400,
           });
         }
@@ -267,7 +295,7 @@ export function registerEndpointTools(
   // /v2/serverless body; v1 passes the flat fields through.
   server.tool(
     'update-endpoint',
-    "Update a Serverless endpoint's config. On v2 you can change image/disk/env/ports/registry/workers/scaling/networkVolumes/timeout/flashboot; on v1, scaling fields (worker min/max, idle timeout, scaler type/value, name). Only provided fields change.",
+    "Update a Serverless endpoint's config. On v2 you can change image/disk/env/ports/registry/workers/scaling/networkVolumes/timeout/flashboot; on v1, scaling fields (worker min/max, idle timeout, scaler type/value, name). Only provided fields change. An endpoint's request routing (queue vs load balancer) is fixed at creation and cannot be changed here — recreate the endpoint instead.",
     {
       endpointId: z.string().describe('ID of the endpoint to update'),
       name: z.string().optional().describe('New name for the endpoint'),
@@ -282,12 +310,21 @@ export function registerEndpointTools(
       idleTimeout: z
         .number()
         .optional()
-        .describe('New idle timeout in seconds'),
+        .describe(
+          'New idle timeout in seconds (1-3600). Does not apply to queue endpoints scaling on REQUEST_COUNT.'
+        ),
       scalerType: z
         .enum(['QUEUE_DELAY', 'REQUEST_COUNT'])
         .optional()
-        .describe('Scaler type'),
-      scalerValue: z.number().optional().describe('Scaler value'),
+        .describe(
+          'New autoscaler signal. Switchable on queue endpoints; load-balancing endpoints only accept REQUEST_COUNT.'
+        ),
+      scalerValue: z
+        .number()
+        .optional()
+        .describe(
+          "New autoscaler target — seconds of queue delay (min 0.5) or in-flight requests per worker (integer, min 1). Applies to the endpoint's current scalerType unless you also pass a new one."
+        ),
       // --- v2-only inline-config fields ---
       imageName: z.string().optional().describe('New Docker image (v2)'),
       gpuPoolIds: z
@@ -326,13 +363,33 @@ export function registerEndpointTools(
     async (params) => {
       const { endpointId, ...updateParams } = params;
       const backend = backendFor('endpoints');
-      const body = backend.mapUpdate(updateParams) as Record<string, unknown>;
-      const result = await callRestUrl(
-        `${backend.base}${backend.get!(endpointId)}`,
-        'PATCH',
-        body
-      );
-      return jsonReply(result);
+      const url = `${backend.base}${backend.get!(endpointId)}`;
+
+      if (backend.version !== 'v2') {
+        const body = backend.mapUpdate(updateParams) as Record<string, unknown>;
+        return jsonReply(await callRestUrl(url, 'PATCH', body));
+      }
+
+      // `scaling` is a union keyed on the scaler type, so a bare "change the target
+      // to N" has no expressible form without knowing which scaler is in effect.
+      // Rather than reject the call, read the endpoint's current scaler and keep
+      // it — which is what such a request has always meant.
+      let scalerType = updateParams.scalerType;
+      if (scalerType === undefined && updateParams.scalerValue !== undefined) {
+        const current = (await callRestUrl(url)) as
+          | { scaling?: { type?: string } }
+          | undefined;
+        scalerType =
+          current?.scaling?.type === 'REQUEST_COUNT'
+            ? 'REQUEST_COUNT'
+            : 'QUEUE_DELAY';
+      }
+
+      const body = backend.mapUpdate({
+        ...updateParams,
+        scalerType,
+      }) as Record<string, unknown>;
+      return jsonReply(await callRestUrl(url, 'PATCH', body));
     }
   );
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1721,6 +1721,61 @@ describe('endpoint routing under RUNPOD_REST_VERSION=v2', () => {
     });
   });
 
+  it('create-endpoint v2 rejects a fractional scalerValue under REQUEST_COUNT', async () => {
+    // REQUEST_COUNT counts whole in-flight requests. The schema can only floor
+    // scalerValue at 0.5 (the QUEUE_DELAY minimum), so the integer half is
+    // checked here, against the scaler actually being sent.
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      const out = await handlers.get('create-endpoint')!({
+        name: 'e',
+        imageName: 'img:2',
+        gpuPoolIds: ['AMPERE_80'],
+        scalerType: 'REQUEST_COUNT',
+        scalerValue: 2.5,
+      });
+      assert.equal(outbound.length, 0);
+      assert.equal(parseText(out).status, 400);
+      assert.match(parseText(out).error as string, /integer >= 1/);
+    });
+  });
+
+  it('create-endpoint v2 applies the integer bound to a LOAD_BALANCER default scaler', async () => {
+    // No scalerType passed: LOAD_BALANCER defaults to REQUEST_COUNT, so the
+    // bound has to be judged on the resolved scaler, not the named one.
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      const out = await handlers.get('create-endpoint')!({
+        name: 'e',
+        imageName: 'img:2',
+        gpuPoolIds: ['AMPERE_80'],
+        endpointType: 'LOAD_BALANCER',
+        scalerValue: 1.5,
+      });
+      assert.equal(outbound.length, 0);
+      assert.equal(parseText(out).status, 400);
+      assert.match(parseText(out).error as string, /integer >= 1/);
+    });
+  });
+
+  it('create-endpoint v2 allows a fractional scalerValue under QUEUE_DELAY', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { id: 'ep_qd' } });
+      await handlers.get('create-endpoint')!({
+        name: 'e',
+        imageName: 'img:2',
+        gpuPoolIds: ['AMPERE_80'],
+        scalerType: 'QUEUE_DELAY',
+        scalerValue: 0.5,
+      });
+      assert.equal(outbound.length, 1);
+      assert.deepEqual(JSON.parse(outbound[0].body!).scaling, {
+        type: 'QUEUE_DELAY',
+        queueDelay: 0.5,
+      });
+    });
+  });
+
   it('create-endpoint v2 defaults LOAD_BALANCER to the REQUEST_COUNT scaler', async () => {
     await withV2(async () => {
       const { handlers, outbound } = harness({ jsonBody: { id: 'ep_lb' } });
@@ -1764,6 +1819,26 @@ describe('endpoint routing under RUNPOD_REST_VERSION=v2', () => {
         type: 'REQUEST_COUNT',
         requestCount: 7,
       });
+    });
+  });
+
+  it('update-endpoint rejects a fractional scalerValue against a REQUEST_COUNT endpoint', async () => {
+    // The caller named no scaler, so the bound can only be judged after the GET
+    // resolves it. The PATCH must not go out.
+    await withV2(async () => {
+      const { handlers, outbound } = harness({
+        steps: [
+          { status: 200, jsonBody: { scaling: { type: 'REQUEST_COUNT' } } },
+        ],
+      });
+      const out = await handlers.get('update-endpoint')!({
+        endpointId: 'ep_1',
+        scalerValue: 7.5,
+      });
+      assert.equal(outbound.length, 1, 'expected the GET only, no PATCH');
+      assert.equal(outbound[0].method, 'GET');
+      assert.equal(parseText(out).status, 400);
+      assert.match(parseText(out).error as string, /integer >= 1/);
     });
   });
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -43,6 +43,11 @@ function harness(opts?: {
   jsonBodies?: unknown[];
   status?: number;
   contentType?: string;
+  // Per-call responses, consumed one per outbound request (falls back to the
+  // single-response options once exhausted). For handlers that make more than one
+  // call with DIFFERENT statuses — e.g. update-endpoint's scaler lookup followed
+  // by the PATCH.
+  steps?: Array<{ status?: number; jsonBody?: unknown; text?: string }>;
   // Fake SSE reader for stream-pod-logs (the real one uses node-fetch directly,
   // bypassing the injected fetch). Records its calls and returns canned text.
   streamSse?: (
@@ -71,8 +76,8 @@ function harness(opts?: {
     },
   } as unknown as McpServer;
 
-  const status = opts?.status ?? 200;
   const queue = opts?.jsonBodies ? [...opts.jsonBodies] : null;
+  const steps = opts?.steps ? [...opts.steps] : null;
   const fakeFetch = async (
     url: string,
     init: { method: string; headers: Record<string, string>; body?: string }
@@ -83,9 +88,13 @@ function harness(opts?: {
       body: init.body,
       headers: init.headers,
     });
-    const jsonBody = queue
-      ? (queue.shift() ?? opts?.jsonBody ?? [])
-      : (opts?.jsonBody ?? []);
+    const step = steps?.shift();
+    const status = step?.status ?? opts?.status ?? 200;
+    const jsonBody = step
+      ? (step.jsonBody ?? {})
+      : queue
+        ? (queue.shift() ?? opts?.jsonBody ?? [])
+        : (opts?.jsonBody ?? []);
     return {
       ok: status >= 200 && status < 300,
       status,
@@ -96,7 +105,7 @@ function harness(opts?: {
             : null,
       },
       json: async () => jsonBody,
-      text: async () => '',
+      text: async () => step?.text ?? '',
     };
   };
 
@@ -1639,12 +1648,11 @@ describe('endpoint routing under RUNPOD_REST_VERSION=v2', () => {
       assert.equal(body.image, 'img:2');
       assert.equal('imageName' in body, false);
       assert.deepEqual(body.gpu, { pools: ['AMPERE_80'], count: 1 });
-      assert.deepEqual(body.workers, { min: 0, max: 3 });
-      assert.deepEqual(body.scaling, {
-        type: 'QUEUE_DELAY',
-        value: 4,
-        idleTimeout: 5,
-      });
+      // Typed schema: routing `type` at the top level, idleTimeout under
+      // `workers`, and the scaler target under a per-variant key.
+      assert.equal(body.type, 'QUEUE');
+      assert.deepEqual(body.workers, { min: 0, max: 3, idleTimeout: 5 });
+      assert.deepEqual(body.scaling, { type: 'QUEUE_DELAY', queueDelay: 4 });
       assert.equal(body.disk, 20);
       assert.deepEqual(body.env, { K: 'V' });
       assert.deepEqual(body.networkVolumes, ['nv_1']);
@@ -1692,6 +1700,102 @@ describe('endpoint routing under RUNPOD_REST_VERSION=v2', () => {
       assert.equal(outbound.length, 0);
       assert.equal(parseText(out).status, 400);
       assert.match(parseText(out).error as string, /gpuPoolIds/);
+    });
+  });
+
+  it('create-endpoint v2 rejects LOAD_BALANCER + QUEUE_DELAY before any request', async () => {
+    // A load balancer has no queue to measure, so the combination can never be
+    // valid — caught client-side rather than spending a round trip on a 422.
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      const out = await handlers.get('create-endpoint')!({
+        name: 'e',
+        imageName: 'img:2',
+        gpuPoolIds: ['AMPERE_80'],
+        endpointType: 'LOAD_BALANCER',
+        scalerType: 'QUEUE_DELAY',
+      });
+      assert.equal(outbound.length, 0);
+      assert.equal(parseText(out).status, 400);
+      assert.match(parseText(out).error as string, /no request queue/);
+    });
+  });
+
+  it('create-endpoint v2 defaults LOAD_BALANCER to the REQUEST_COUNT scaler', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { id: 'ep_lb' } });
+      await handlers.get('create-endpoint')!({
+        name: 'e',
+        imageName: 'img:2',
+        gpuPoolIds: ['AMPERE_80'],
+        endpointType: 'LOAD_BALANCER',
+      });
+      const body = JSON.parse(outbound[0].body!);
+      assert.equal(body.type, 'LOAD_BALANCER');
+      assert.deepEqual(body.scaling, {
+        type: 'REQUEST_COUNT',
+        requestCount: 4,
+      });
+    });
+  });
+
+  it('update-endpoint reads the current scaler when only scalerValue is given', async () => {
+    // `scaling` is a union keyed on the scaler type, so changing just the target
+    // needs the endpoint's existing scaler first — a GET, then the PATCH.
+    await withV2(async () => {
+      const { handlers, outbound } = harness({
+        steps: [
+          { status: 200, jsonBody: { scaling: { type: 'REQUEST_COUNT' } } },
+          { status: 200, jsonBody: { id: 'ep_1' } },
+        ],
+      });
+      await handlers.get('update-endpoint')!({
+        endpointId: 'ep_1',
+        scalerValue: 7,
+      });
+      assert.equal(outbound.length, 2);
+      assert.equal(outbound[0].method, 'GET');
+      assert.equal(
+        outbound[0].url,
+        'https://v2-rest.runpod.io/v2/serverless/ep_1'
+      );
+      assert.equal(outbound[1].method, 'PATCH');
+      assert.deepEqual(JSON.parse(outbound[1].body!).scaling, {
+        type: 'REQUEST_COUNT',
+        requestCount: 7,
+      });
+    });
+  });
+
+  it('update-endpoint treats an unrecognized current scaler as QUEUE_DELAY', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({
+        steps: [
+          { status: 200, jsonBody: { scaling: {} } },
+          { status: 200, jsonBody: { id: 'ep_1' } },
+        ],
+      });
+      await handlers.get('update-endpoint')!({
+        endpointId: 'ep_1',
+        scalerValue: 3,
+      });
+      assert.deepEqual(JSON.parse(outbound[1].body!).scaling, {
+        type: 'QUEUE_DELAY',
+        queueDelay: 3,
+      });
+    });
+  });
+
+  it('update-endpoint skips that read when the caller names the scaler', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { id: 'ep_1' } });
+      await handlers.get('update-endpoint')!({
+        endpointId: 'ep_1',
+        scalerType: 'QUEUE_DELAY',
+        scalerValue: 3,
+      });
+      assert.equal(outbound.length, 1);
+      assert.equal(outbound[0].method, 'PATCH');
     });
   });
 

--- a/tests/mappers.test.ts
+++ b/tests/mappers.test.ts
@@ -324,42 +324,75 @@ describe('podBodyFromTemplate', () => {
   });
 });
 
+// Full-fidelity tool params for the golden body below.
+const FULL_ENDPOINT_PARAMS = {
+  name: 'e',
+  imageName: 'img:2',
+  args: '--port 8000',
+  gpuPoolIds: ['AMPERE_80'],
+  gpuCount: 1,
+  workersMin: 0,
+  workersMax: 3,
+  scalerType: 'QUEUE_DELAY' as const,
+  scalerValue: 4,
+  idleTimeout: 5,
+  containerDiskInGb: 20,
+  ports: ['8000/http'],
+  env: { K: 'V' },
+  containerRegistryAuthId: 'cra_1',
+  networkVolumeIds: ['nv_1'],
+  executionTimeoutMs: 600000,
+  flashboot: 'FLASHBOOT' as const,
+};
+
+const SHARED_ENDPOINT_BODY = {
+  name: 'e',
+  image: 'img:2',
+  args: '--port 8000',
+  disk: 20,
+  ports: ['8000/http'],
+  env: { K: 'V' },
+  registry: 'cra_1',
+  gpu: { pools: ['AMPERE_80'], count: 1 },
+  networkVolumes: ['nv_1'],
+  timeout: 600000,
+  flashboot: 'FLASHBOOT',
+};
+
 describe('mapEndpointCreateToV2', () => {
-  it('builds the nested v2 /serverless body (gpu.pools/workers/scaling)', () => {
+  it('builds the v2 /serverless body (type + workers.idleTimeout + union scaling)', () => {
+    assert.deepEqual(mapEndpointCreateToV2(FULL_ENDPOINT_PARAMS), {
+      ...SHARED_ENDPOINT_BODY,
+      type: 'QUEUE',
+      workers: { min: 0, max: 3, idleTimeout: 5 },
+      scaling: { type: 'QUEUE_DELAY', queueDelay: 4 },
+    });
+  });
+
+  it('defaults type/scaling, which the typed schema requires', () => {
+    const out = mapEndpointCreateToV2({ imageName: 'i', gpuPoolIds: ['P'] });
+    assert.equal(out.type, 'QUEUE');
+    assert.deepEqual(out.scaling, { type: 'QUEUE_DELAY', queueDelay: 4 });
+  });
+
+  it('LOAD_BALANCER defaults to the REQUEST_COUNT scaler (its only legal one)', () => {
     const out = mapEndpointCreateToV2({
-      name: 'e',
-      imageName: 'img:2',
-      args: '--port 8000',
-      gpuPoolIds: ['AMPERE_80'],
-      gpuCount: 1,
-      workersMin: 0,
-      workersMax: 3,
-      scalerType: 'QUEUE_DELAY',
-      scalerValue: 4,
-      idleTimeout: 5,
-      containerDiskInGb: 20,
-      ports: ['8000/http'],
-      env: { K: 'V' },
-      containerRegistryAuthId: 'cra_1',
-      networkVolumeIds: ['nv_1'],
-      executionTimeoutMs: 600000,
-      flashboot: 'FLASHBOOT',
+      imageName: 'i',
+      gpuPoolIds: ['P'],
+      endpointType: 'LOAD_BALANCER',
     });
-    assert.deepEqual(out, {
-      name: 'e',
-      image: 'img:2',
-      args: '--port 8000',
-      disk: 20,
-      ports: ['8000/http'],
-      env: { K: 'V' },
-      registry: 'cra_1',
-      gpu: { pools: ['AMPERE_80'], count: 1 },
-      workers: { min: 0, max: 3 },
-      scaling: { type: 'QUEUE_DELAY', value: 4, idleTimeout: 5 },
-      networkVolumes: ['nv_1'],
-      timeout: 600000,
-      flashboot: 'FLASHBOOT',
+    assert.equal(out.type, 'LOAD_BALANCER');
+    assert.deepEqual(out.scaling, { type: 'REQUEST_COUNT', requestCount: 4 });
+  });
+
+  it('an explicit scalerType still wins over the per-type default', () => {
+    const out = mapEndpointCreateToV2({
+      imageName: 'i',
+      endpointType: 'QUEUE',
+      scalerType: 'REQUEST_COUNT',
+      scalerValue: 2,
     });
+    assert.deepEqual(out.scaling, { type: 'REQUEST_COUNT', requestCount: 2 });
   });
 
   it('imageName→image, containerRegistryAuthId→registry, networkVolumeIds→networkVolumes', () => {
@@ -385,22 +418,61 @@ describe('mapEndpointCreateToV2', () => {
     assert.equal('gpu' in out, false);
   });
 
-  it('drops empty workers/scaling objects', () => {
+  it('drops an empty workers object but always emits scaling (required)', () => {
     const out = mapEndpointCreateToV2({ imageName: 'i' });
     assert.equal('workers' in out, false);
-    assert.equal('scaling' in out, false);
+    assert.deepEqual(out.scaling, { type: 'QUEUE_DELAY', queueDelay: 4 });
   });
 
   it('emits workers.min:0 (a meaningful scale-to-zero, not dropped)', () => {
     const out = mapEndpointCreateToV2({ imageName: 'i', workersMin: 0 });
     assert.deepEqual(out.workers, { min: 0 });
   });
+
+  it('routes idleTimeout to workers, never to scaling', () => {
+    const out = mapEndpointCreateToV2({ imageName: 'i', idleTimeout: 7 });
+    assert.deepEqual(out.workers, { idleTimeout: 7 });
+    assert.equal('idleTimeout' in (out.scaling as object), false);
+  });
 });
 
 describe('mapEndpointUpdateToV2', () => {
-  it('is the same shape as create (every field optional)', () => {
+  it('maps only the provided fields', () => {
     const out = mapEndpointUpdateToV2({ workersMax: 5, imageName: 'img:3' });
     assert.deepEqual(out, { workers: { max: 5 }, image: 'img:3' });
+  });
+
+  it('never sends `type` — the typed API rejects it on PATCH', () => {
+    const out = mapEndpointUpdateToV2({ endpointType: 'LOAD_BALANCER' });
+    assert.equal('type' in out, false);
+  });
+
+  it('omits scaling entirely when no scalerType is given', () => {
+    const out = mapEndpointUpdateToV2({ scalerValue: 9 });
+    assert.equal('scaling' in out, false);
+  });
+
+  it('scalerType alone implies the default target the union requires', () => {
+    const out = mapEndpointUpdateToV2({ scalerType: 'REQUEST_COUNT' });
+    assert.deepEqual(out.scaling, { type: 'REQUEST_COUNT', requestCount: 4 });
+  });
+
+  it('builds the union variant matching the scalerType', () => {
+    assert.deepEqual(
+      mapEndpointUpdateToV2({ scalerType: 'QUEUE_DELAY', scalerValue: 0.5 })
+        .scaling,
+      { type: 'QUEUE_DELAY', queueDelay: 0.5 }
+    );
+  });
+
+  it('routes idleTimeout to workers, never into scaling', () => {
+    const out = mapEndpointUpdateToV2({
+      scalerType: 'QUEUE_DELAY',
+      scalerValue: 6,
+      idleTimeout: 9,
+    });
+    assert.deepEqual(out.scaling, { type: 'QUEUE_DELAY', queueDelay: 6 });
+    assert.deepEqual(out.workers, { idleTimeout: 9 });
   });
 });
 

--- a/tests/tools-registration.test.ts
+++ b/tests/tools-registration.test.ts
@@ -178,4 +178,48 @@ describe('tool registration', () => {
       assert.ok('cursor' in schema, `${tool} missing 'cursor' param`);
     }
   });
+
+  // The autoscaling bounds are in the v2 spec, so an out-of-range value can be
+  // refused here instead of spending a round trip on a 422. Asserted on the
+  // registered zod schema because the handler tests call handlers directly and
+  // never run parameter validation.
+  describe('autoscaling parameter bounds', () => {
+    const parse = (tool: string, param: string, value: unknown) => {
+      const { schemas } = captureRegisteredTools();
+      const schema = schemas.get(tool);
+      assert.ok(schema, `no schema captured for ${tool}`);
+      const field = schema[param] as {
+        safeParse: (v: unknown) => { success: boolean };
+      };
+      assert.ok(
+        field && typeof field.safeParse === 'function',
+        `${tool}.${param} is not a zod schema`
+      );
+      return field.safeParse(value).success;
+    };
+
+    for (const tool of ['create-endpoint', 'update-endpoint']) {
+      it(`${tool} bounds idleTimeout to an integer 1-3600`, () => {
+        assert.equal(parse(tool, 'idleTimeout', 1), true);
+        assert.equal(parse(tool, 'idleTimeout', 3600), true);
+        assert.equal(parse(tool, 'idleTimeout', 0), false, 'accepted 0');
+        assert.equal(parse(tool, 'idleTimeout', 3601), false, 'accepted 3601');
+        assert.equal(
+          parse(tool, 'idleTimeout', 12.5),
+          false,
+          'accepted a float'
+        );
+      });
+
+      it(`${tool} floors scalerValue at the QUEUE_DELAY minimum (0.5)`, () => {
+        // The looser of the two union bounds — REQUEST_COUNT additionally
+        // requires an integer, which is enforced per-call once the scaler that
+        // will be sent is known (see the handler tests).
+        assert.equal(parse(tool, 'scalerValue', 0.5), true);
+        assert.equal(parse(tool, 'scalerValue', 4), true);
+        assert.equal(parse(tool, 'scalerValue', 0.4), false, 'accepted 0.4');
+        assert.equal(parse(tool, 'scalerValue', 0), false, 'accepted 0');
+      });
+    }
+  });
 });


### PR DESCRIPTION
`/v2/serverless` changed its create/update contract. `create-endpoint` and `update-endpoint` were sending the old shape and getting a `422`. This sends the new one.

> ⚠️ **Do not merge/release until production serves the new schema.** This targets the new shape *only* — there is no fallback. Against a host still on the old one, endpoint create/update fail (see below). Production has not promoted yet.

### What changed upstream

| | old | new |
|---|---|---|
| `type` | not on create | **required**, `QUEUE` \| `LOAD_BALANCER` |
| `scaling` | `{type, value, idleTimeout}` | `{type, queueDelay}` or `{type, requestCount}` |
| `idleTimeout` | inside `scaling` | moved to `workers` |

### Tool surface

Unchanged for existing callers — `scalerType` / `scalerValue` / `idleTimeout` keep their names and map onto the new shape. `scalerValue` defaults to `4`; passing it alone on update keeps the endpoint's current scaler.

New: **`endpointType`** on `create-endpoint` for queue-based (default) vs load-balancing routing. Fixed at creation.

`get-endpoint` / `list-endpoints` now point at `requestUrls` for an endpoint's URLs rather than having callers assemble them.

---

<details>
<summary>The 422 this fixes, and the one it introduces</summary>

Old body → new host (what `main` does today):
```
422 ["$: missing property 'type'",
     "$.scaling: missing property 'queueDelay'",
     "$.scaling: additional properties 'value', 'idleTimeout' not allowed"]
```

New body → old host (what this branch does against prod today, measured):
```
422 ["$.workers: additional properties 'idleTimeout' not allowed",
     "$.scaling: additional properties 'queueDelay' not allowed"]
```

Nothing is created by that rejection — validation runs before provisioning, and a leftover sweep after the probe came back empty.

Business-rule `422`s pass through verbatim, e.g. `"idleTimeout does not apply to queue-based endpoints scaling on requestCount"` and `"scaler field does not match endpoint type…"`. The API's own sentence is the useful one.

</details>

<details>
<summary>Test plan</summary>

312 tests; tsc, eslint, prettier, build clean.

Live end to end through the real handlers against dev (which has the new schema):

| check | |
|---|---|
| create `QUEUE` with defaults | ✅ |
| create `LOAD_BALANCER` | ✅ `requestUrls.base` + `health` |
| `get-endpoint` → `type` + `requestUrls` | ✅ |
| update `scalerValue` alone | ✅ keeps current scaler |
| switch `QUEUE_DELAY` ⇄ `REQUEST_COUNT` | ✅ both directions |
| `idleTimeout` on a `REQUEST_COUNT` queue endpoint | ✅ informative 422, verbatim |
| `LOAD_BALANCER` + `QUEUE_DELAY` | ✅ informative 422, verbatim |
| delete | ✅ 204 |

All `mcptest-*` swept; both accounts verified clean.

</details>

<details>
<summary>History: this started as a dual-shape negotiation</summary>

The first version of this PR supported both generations, negotiating per host: send the new shape, and on a shape-complaint `422` retry with the old one and remember the answer. That let it merge before promotion.

Simplified to a single shape on the call that dev's changes will reach production first. Removed with it: `src/_shared/serverless-schema.ts`, the per-host memo, the rejection classifier, `RUNPOD_SERVERLESS_SCHEMA`, the `LOAD_BALANCER`-on-old-host refusal, and 28 negotiation tests.

The tradeoff is the ⚠️ at the top: less machinery, but the merge is now gated on promotion instead of being safe at any time.

</details>

---

**Interacts with #59** (the spec resync). Two conflicting files, both intentional:

- `src/_shared/mappers.ts` — #59 carries a ⚠️ note saying these mappers do not match the vendored spec for endpoints. **This PR makes that false — take this side and drop the note.**
- `README.md` — both add a `###` section near the version-config notes. Keep both, order them.

`tests/fixtures/v2-openapi.yaml` and `tests/spec-parity.test.ts` are deliberately **not** in this PR — re-vendoring the spec is #59's job, and doing it here dragged in unrelated tag/delegation allowlist churn.

- Plugin docs counterpart: runpod/runpod-plugins-official#38
- Linear: [CON-817](https://linear.app/runpod/issue/CON-817/runpod-mcp-official-plugin-v2-v2serverless-write-schema-break-endpoint)
