### PR TITLE
fix: guard v2-required pod name in create-pod

### DIFF
--- a/.changeset/create-pod-name-guard.md
+++ b/.changeset/create-pod-name-guard.md
@@ -1,0 +1,5 @@
+---
+'@runpod/mcp-server': patch
+---
+
+`create-pod` now returns a clean local 400 when `name` is omitted on a v2 GPU create without a `templateId`, matching the v2 spec (`CreatePodRequest` requires `name`) instead of surfacing the API's raw 422. Template deploys (name inherited from the template) and CPU pods (routed to v1) are unaffected.

--- a/src/tools/pods.ts
+++ b/src/tools/pods.ts
@@ -139,7 +139,12 @@ export function registerPodTools(server: McpServer, rt: ToolRuntime): void {
     'create-pod',
     'Create a new GPU/CPU pod on Runpod. Pass gpuTypeIds for a GPU pod, or computeType:"CPU" for a CPU pod (CPU pods are served by the v1 API for now). Pass either imageName or templateId (templateId deploys from an existing template — its name, image, start command, ports, env, disk, volume, and registry credential are used as defaults, and any field you also pass explicitly replaces the template value for that field, e.g. passing env replaces the whole env set rather than merging; pass containerRegistryAuthId to override or supply a private-image credential, or an empty string to deploy with none). If the user specifies neither an image nor a template, recommend the "Runpod Pytorch 2.8.0" image (runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404) as the default — it has the most up-to-date CUDA and PyTorch versions.',
     {
-      name: z.string().optional().describe('Name for the pod'),
+      name: z
+        .string()
+        .optional()
+        .describe(
+          'Name for the pod. Required on v2 unless deploying from a templateId (the template supplies its name as the default).'
+        ),
       imageName: z
         .string()
         .optional()
@@ -242,6 +247,17 @@ export function registerPodTools(server: McpServer, rt: ToolRuntime): void {
           return jsonReply({
             error:
               'A GPU pod needs gpuTypeIds (see list-gpu-types); gpuCount or computeType alone is under-specified.',
+            status: 400,
+          });
+        }
+        // v2 CreatePodRequest requires `name`. Guard the direct-image path so
+        // the caller gets a clean 400 instead of the API's raw 422; a
+        // templateId deploy inherits the template's name below. CPU pods fall
+        // through to v1, which has no such requirement.
+        if (!wantsCpu && !params.name && !params.templateId) {
+          return jsonReply({
+            error:
+              'Provide a name for the pod (deploying from a templateId inherits the template name).',
             status: 400,
           });
         }

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -546,6 +546,7 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
       const { handlers, outbound } = harness({ jsonBody: {} });
       // gpuTypeIds present so it stays on v2 (a GPU-less create routes to v1).
       await handlers.get('create-pod')!({
+        name: 'p',
         imageName: 'i',
         gpuTypeIds: ['A100'],
         volumeInGb: 40,
@@ -577,6 +578,7 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
     await withV2(async () => {
       const { handlers, outbound } = harness({ jsonBody: { id: 'pod_multi' } });
       const out = (await handlers.get('create-pod')!({
+        name: 'p',
         imageName: 'i',
         gpuTypeIds: ['A100', 'H100', 'L40'],
       })) as { content: Array<{ text: string }> };
@@ -619,6 +621,31 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
       const payload = JSON.parse(out.content[0].text);
       assert.equal(payload.status, 400);
       assert.match(payload.error, /A GPU pod needs gpuTypeIds/);
+    });
+  });
+
+  it('create-pod v2 GPU create with no name and no templateId → 400, no request (v2 requires name)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      const out = (await handlers.get('create-pod')!({
+        imageName: 'i',
+        gpuTypeIds: ['A100'],
+      })) as { content: Array<{ text: string }> };
+      assert.equal(outbound.length, 0, 'must not fire a request');
+      const payload = JSON.parse(out.content[0].text);
+      assert.equal(payload.status, 400);
+      assert.match(payload.error, /Provide a name/);
+    });
+  });
+
+  it('create-pod v2 CPU pod without a name still routes to v1 (name is a v2-only requirement)', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: { id: 'pod_cpu' } });
+      await handlers.get('create-pod')!({
+        imageName: 'i',
+        computeType: 'CPU',
+      });
+      assert.equal(outbound[0].url, 'https://rest.runpod.io/v1/pods');
     });
   });
 
@@ -803,6 +830,7 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
       // Must RESOLVE (not reject) so the model sees a readable error rather than
       // a raw thrown stack.
       const out = (await handlers.get('create-pod')!({
+        name: 'p',
         imageName: 'i',
         gpuTypeIds: ['A100'],
       })) as { content: Array<{ text: string }> };
@@ -819,6 +847,7 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
     await withV2(async () => {
       const { handlers } = harness({ status: 501, jsonBody: {} });
       const out = (await handlers.get('create-pod')!({
+        name: 'p',
         imageName: 'i',
         gpuTypeIds: ['A100'],
       })) as { content: Array<{ text: string }> };


### PR DESCRIPTION
## Why

Found while auditing every tool call against the live v2 OpenAPI spec (`api.runpod.io/v2/openapi.json`, follow-up to #74/#75): `CreatePodRequest` marks `name` **required**, but `create-pod`'s schema has it optional with no handler guard. A direct-image GPU create without a name sent a body the spec rejects — the caller got the API's raw 422 instead of a clean local error. `create-endpoint` already guards `name` for exactly this reason, and every other create tool requires it in its zod schema; `create-pod` was the one inconsistency.

## What

- **`src/tools/pods.ts`**: on the v2 GPU direct-image path, a missing `name` (with no `templateId`) now returns a local 400: "Provide a name for the pod (deploying from a templateId inherits the template name)." The guard deliberately does **not** apply where the spec doesn't:
  - **Template deploys** pass through — the template's `name` is merged in as the default (pinned by the existing template-merge test asserting `body.name === 'pytorch-template'`).
  - **CPU pods** pass through — they route to v1, which has no such requirement (new test).
- `name` param description updated so agents know when it's required.
- Four existing tests that exercised the v2 POST without a name now pass one; two new tests pin the guard and the CPU pass-through.
- Changeset: patch.

## Spec-audit context

This was the only inconsistency found. Everything else checked out: all 15 v2 paths/methods the tools construct exist in the spec; all query params (logs `source`/`tail`/`since`, billing windows/buckets/`lastN`, catalog `include=AVAILABILITY`) match including enums; all request bodies match field-for-field after resolving `$ref`/`allOf` (incl. the `additionalProperties: false` schemas); v1-only query filters are correctly never sent on v2; and the vendored parity fixture's operation set is identical to the live prod spec.

## Test plan

- `pnpm build` / `pnpm lint` clean, `pnpm test` 527 pass / 0 fail (8 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)