### PR TITLE
fix(http): refuse the standalone GET SSE stream with 405

### DIFF
--- a/.changeset/refuse-standalone-get-sse.md
+++ b/.changeset/refuse-standalone-get-sse.md
@@ -1,0 +1,5 @@
+---
+'@runpod/mcp-server': patch
+---
+
+Refuse the standalone GET SSE stream with 405. The HTTP server is stateless and never sends server-initiated messages, so the GET "listen" stream has nothing to carry — but the SDK accepted it anyway and held the response open with nothing to send until the platform's maxDuration killed it, at which point every connected client immediately re-opened it. On the hosted deployment that loop was ~1.1M hung requests per day (90% of all traffic), each ending in a 60-second timeout, and it dominated the serverless bill. GET now gets the spec's answer for a server without an SSE stream: 405 Method Not Allowed with an `Allow: POST, DELETE` header and a JSON-RPC error body, before any auth work — a 401 there would send OAuth clients into a pointless re-auth flow. Clients per the MCP spec treat the 405 as "no server-initiated messages offered" and continue POST-only; tool calls are unaffected.

--- a/src/http.ts
+++ b/src/http.ts
@@ -338,6 +338,27 @@ export async function handleMcpRequest(
     url: req.url,
     hasBearerToken: !!bearerToken,
   });
+  // Stateless server: there are no server-initiated messages, so the standalone
+  // GET SSE stream has nothing to carry. Per spec, answer 405 instead of letting
+  // the SDK hold an idle stream open until the platform kills it.
+  if (req.method === 'GET') {
+    res.writeHead(405, {
+      Allow: 'POST, DELETE',
+      'Content-Type': 'application/json',
+    });
+    res.end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message:
+            'Method Not Allowed: this server does not offer a standalone SSE stream.',
+        },
+        id: null,
+      })
+    );
+    return;
+  }
   if (!bearerToken) {
     writeUnauthorized(
       req,

--- a/tests/credential-check.test.ts
+++ b/tests/credential-check.test.ts
@@ -372,6 +372,41 @@ function fakeReqRes(
   return { req, res, written };
 }
 
+describe('handleMcpRequest — standalone GET SSE stream is refused', () => {
+  // Stateless server: no server-initiated messages, so GET gets the spec's
+  // 405 rather than an idle open SSE stream.
+  it('GET → 405 with Allow, JSON-RPC error body, and no credential check', async () => {
+    let checkerCalls = 0;
+    const { req, res, written } = fakeReqRes(
+      { authorization: 'Bearer rpa_x', accept: 'text/event-stream' },
+      { method: 'GET' }
+    );
+    await handleMcpRequest(req, res, {
+      verifyCredential: async () => {
+        checkerCalls++;
+        return { status: 'valid' as const };
+      },
+    });
+    assert.equal(written.statusCode, 405);
+    assert.equal(written.headers!['Allow'], 'POST, DELETE');
+    const body = JSON.parse(written.body!) as {
+      jsonrpc: string;
+      error: { code: number; message: string };
+    };
+    assert.equal(body.jsonrpc, '2.0');
+    assert.equal(body.error.code, -32000);
+    assert.match(body.error.message, /Method Not Allowed/);
+    assert.equal(checkerCalls, 0);
+  });
+
+  it('unauthenticated GET → 405, not 401 (a 401 would trigger a pointless re-auth flow)', async () => {
+    const { req, res, written } = fakeReqRes({}, { method: 'GET' });
+    await handleMcpRequest(req, res, {});
+    assert.equal(written.statusCode, 405);
+    assert.equal(written.headers!['WWW-Authenticate'], undefined);
+  });
+});
+
 describe('handleMcpRequest — credential pre-flight', () => {
   it('dead credential → HTTP 401 with WWW-Authenticate resource metadata (the re-auth trigger)', async () => {
     const { req, res, written } = fakeReqRes({
@@ -788,7 +823,9 @@ describe('env-mismatch guard keys off the RESOLVED host, not mere presence', () 
     // environment — normalizing it into prod would validate dev keys against
     // prod GraphQL and 401 every request the tools could have served.
     assert.equal(
-      await gateRan({ RUNPOD_REST_V2_API_URL: 'https://v2-rest.runpod.dev/v2' }),
+      await gateRan({
+        RUNPOD_REST_V2_API_URL: 'https://v2-rest.runpod.dev/v2',
+      }),
       false
     );
   });
@@ -1250,8 +1287,9 @@ describe('credential_check log line', () => {
   });
 
   it('distinguishes each skip reason', async () => {
+    // DELETE: GET is answered 405 before the gate runs.
     assert.deepEqual(
-      await outcomeFor({ authorization: 'Bearer x' }, true, 'GET'),
+      await outcomeFor({ authorization: 'Bearer x' }, true, 'DELETE'),
       ['skip_not_post']
     );
     assert.deepEqual(


### PR DESCRIPTION
## Description

Answer `GET` on the MCP endpoint with **405 Method Not Allowed** (`Allow: POST, DELETE`, JSON-RPC error body) instead of letting the SDK accept it. Per the MCP spec, a server that offers no server-initiated messages MUST return 405 for the standalone SSE stream, clients then continue POST-only, and tool calls are unaffected.

## How

- `handleMcpRequest` short-circuits `GET` before any auth work. 405 (not 401) on unauthenticated GETs too, a 401 there pushes OAuth-capable clients into a pointless re-auth flow.
- `DELETE` unchanged (SDK answers it quickly in stateless mode), so it stays in `Allow`.
- Existing skip-reason logging test switched from GET to DELETE to keep exercising the `skip_not_post` path.

## Tests

- New: GET → 405 with `Allow`, JSON-RPC error body, and no credential-checker call; unauthenticated GET → 405 with no `WWW-Authenticate`.
- Full suite: 530 pass / 0 fail; type-check, lint, build clean.