### PR TITLE
chore: skip preview deployments, build production only

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "pnpm build",
+  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 1 || exit 0",
   "outputDirectory": "public",
   "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }],
   "functions": {


### PR DESCRIPTION
Preview deployments serve no purpose for this project (verified) — the MCP server is only ever consumed at the production URL, and previews on this public repo were deployed and never used.

This adds Vercel's Ignored Build Step to `vercel.json`: exit 1 = build (production), exit 0 = skip (everything else). Production deploys from `main` are unaffected; PR preview builds are skipped, which also stops the Vercel bot comments.

Notes:
- Already-deployed preview URLs remain live (Vercel deployments are immutable) — delete old previews or enable Vercel Authentication if we want those gated too.
- One-off previews are still possible manually via `vercel deploy`.
- Since the ignore command is read from the deployed commit, this PR's own preview build should already show as skipped.