### PR TITLE
chore: serve OAuth discovery metadata from the CDN

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -288,11 +288,20 @@ function encodeBody(body: VercelRequest['body']): string {
   return '';
 }
 
+// The discovery documents are static per host, and MCP clients re-fetch them
+// as part of every auth flow. s-maxage serves those fetches from the CDN
+// instead of invoking the function; stale-while-revalidate keeps expiry from
+// re-serializing invocations. Clients themselves get max-age=0 so a deploy
+// that changes the advertised endpoints propagates immediately.
+const DISCOVERY_CACHE_CONTROL =
+  'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400';
+
 function handleProtectedResourceMetadata(
   req: VercelRequest,
   res: VercelResponse
 ): void {
   const baseUrl = getBaseUrl(req);
+  res.setHeader('Cache-Control', DISCOVERY_CACHE_CONTROL);
   // Advertise THIS server as the authorization server so Claude discovers our
   // /authorize and /token routes.
   res.status(200).json({
@@ -308,6 +317,7 @@ function handleAuthorizationServerMetadata(
   res: VercelResponse
 ): void {
   const baseUrl = getBaseUrl(req);
+  res.setHeader('Cache-Control', DISCOVERY_CACHE_CONTROL);
   // This server is the full authorization server. The flow is a flash-backed
   // approval: /authorize creates a request and hands off to the console, and
   // /token exchanges the resulting code for the minted Runpod API key. There is

--- a/api/index.ts
+++ b/api/index.ts
@@ -288,11 +288,11 @@ function encodeBody(body: VercelRequest['body']): string {
   return '';
 }
 
-// The discovery documents are static per host, and MCP clients re-fetch them
-// as part of every auth flow. s-maxage serves those fetches from the CDN
-// instead of invoking the function; stale-while-revalidate keeps expiry from
-// re-serializing invocations. Clients themselves get max-age=0 so a deploy
-// that changes the advertised endpoints propagates immediately.
+// The discovery documents are static per host and fetched by MCP clients on
+// every auth flow. s-maxage serves repeat fetches from the CDN instead of the
+// function; stale-while-revalidate revalidates expired copies in the
+// background; max-age=0 keeps clients uncached so a deploy that changes the
+// advertised endpoints propagates within the hour.
 const DISCOVERY_CACHE_CONTROL =
   'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400';
 

--- a/tests/discovery-cache.test.ts
+++ b/tests/discovery-cache.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import handler from '../api/index.js';
+
+// The OAuth discovery documents are static per host and fetched on every auth
+// flow, so they must carry a CDN caching directive to be served from the edge
+// instead of invoking the function. These tests pin the directive onto the two
+// discovery routes — and pin it OFF the MCP endpoint itself, whose responses
+// are per-caller and must never be cached.
+
+function fakeReqRes(method: string, url: string) {
+  const state: Record<string, string> = {};
+  const req = {
+    method,
+    url,
+    headers: { host: 'mcp.test' },
+    body: undefined,
+    on() {},
+  } as unknown as Parameters<typeof handler>[0];
+  const res = {
+    setHeader(name: string, value: string) {
+      state[name] = value;
+      return this;
+    },
+    getHeader(name: string) {
+      return state[name];
+    },
+    status() {
+      return this;
+    },
+    json() {
+      return this;
+    },
+    send() {
+      return this;
+    },
+    end() {
+      return this;
+    },
+    writeHead() {
+      return this;
+    },
+    on() {},
+  } as unknown as Parameters<typeof handler>[1];
+  return { req, res, state };
+}
+
+describe('OAuth discovery responses are CDN-cacheable', () => {
+  for (const path of [
+    '/.well-known/oauth-protected-resource',
+    '/.well-known/oauth-authorization-server',
+  ]) {
+    it(`GET ${path} carries s-maxage so the CDN serves repeat fetches`, async () => {
+      const { req, res, state } = fakeReqRes('GET', path);
+      await handler(req, res).catch(() => {});
+      const cacheControl = state['Cache-Control'];
+      assert.ok(cacheControl, 'no Cache-Control set on the discovery response');
+      assert.match(cacheControl, /\bpublic\b/);
+      assert.match(cacheControl, /\bs-maxage=[1-9]\d*/);
+      // Clients must not cache locally: a deploy that changes the advertised
+      // endpoints has to propagate as soon as the CDN copy expires.
+      assert.match(cacheControl, /\bmax-age=0\b/);
+    });
+  }
+
+  it('the MCP endpoint itself is never marked cacheable', async () => {
+    // Pin the directive's absence on the catch-all route so it can never
+    // migrate into the shared prelude in api/index.ts, where the CDN would
+    // start caching per-caller MCP responses.
+    const { req, res, state } = fakeReqRes('POST', '/');
+    await handler(req, res).catch(() => {});
+    assert.equal(state['Cache-Control'], undefined);
+  });
+});

--- a/tests/discovery-cache.test.ts
+++ b/tests/discovery-cache.test.ts
@@ -3,11 +3,10 @@ import assert from 'node:assert/strict';
 
 import handler from '../api/index.js';
 
-// The OAuth discovery documents are static per host and fetched on every auth
-// flow, so they must carry a CDN caching directive to be served from the edge
-// instead of invoking the function. These tests pin the directive onto the two
-// discovery routes — and pin it OFF the MCP endpoint itself, whose responses
-// are per-caller and must never be cached.
+// The OAuth discovery documents are static per host, so they carry a CDN
+// caching directive and repeat fetches skip the function. These tests pin the
+// directive onto the two discovery routes and off the MCP endpoint, whose
+// responses are per-caller.
 
 function fakeReqRes(method: string, url: string) {
   const state: Record<string, string> = {};
@@ -58,16 +57,15 @@ describe('OAuth discovery responses are CDN-cacheable', () => {
       assert.ok(cacheControl, 'no Cache-Control set on the discovery response');
       assert.match(cacheControl, /\bpublic\b/);
       assert.match(cacheControl, /\bs-maxage=[1-9]\d*/);
-      // Clients must not cache locally: a deploy that changes the advertised
-      // endpoints has to propagate as soon as the CDN copy expires.
+      // max-age=0: endpoint changes propagate as soon as the CDN copy expires.
       assert.match(cacheControl, /\bmax-age=0\b/);
     });
   }
 
   it('the MCP endpoint itself is never marked cacheable', async () => {
-    // Pin the directive's absence on the catch-all route so it can never
-    // migrate into the shared prelude in api/index.ts, where the CDN would
-    // start caching per-caller MCP responses.
+    // MCP responses are per-caller; a CDN-cached copy would replay one
+    // caller's response to another. Pin the directive's absence on the
+    // catch-all route so it stays out of the shared prelude in api/index.ts.
     const { req, res, state } = fakeReqRes('POST', '/');
     await handler(req, res).catch(() => {});
     assert.equal(state['Cache-Control'], undefined);

--- a/tests/discovery-cache.test.ts
+++ b/tests/discovery-cache.test.ts
@@ -10,6 +10,7 @@ import handler from '../api/index.js';
 
 function fakeReqRes(method: string, url: string) {
   const state: Record<string, string> = {};
+  let statusCode: number | undefined;
   const req = {
     method,
     url,
@@ -25,7 +26,8 @@ function fakeReqRes(method: string, url: string) {
     getHeader(name: string) {
       return state[name];
     },
-    status() {
+    status(code: number) {
+      statusCode = code;
       return this;
     },
     json() {
@@ -37,12 +39,13 @@ function fakeReqRes(method: string, url: string) {
     end() {
       return this;
     },
-    writeHead() {
+    writeHead(code: number) {
+      statusCode = code;
       return this;
     },
     on() {},
   } as unknown as Parameters<typeof handler>[1];
-  return { req, res, state };
+  return { req, res, state, status: () => statusCode };
 }
 
 describe('OAuth discovery responses are CDN-cacheable', () => {
@@ -51,12 +54,17 @@ describe('OAuth discovery responses are CDN-cacheable', () => {
     '/.well-known/oauth-authorization-server',
   ]) {
     it(`GET ${path} carries s-maxage so the CDN serves repeat fetches`, async () => {
-      const { req, res, state } = fakeReqRes('GET', path);
-      await handler(req, res).catch(() => {});
+      const { req, res, state, status } = fakeReqRes('GET', path);
+      await handler(req, res);
+      // Assert the route answered before asserting on its headers: a handler
+      // that threw, or a path that fell through to 404, would otherwise
+      // satisfy every header check below by simply setting nothing.
+      assert.equal(status(), 200);
       const cacheControl = state['Cache-Control'];
       assert.ok(cacheControl, 'no Cache-Control set on the discovery response');
       assert.match(cacheControl, /\bpublic\b/);
       assert.match(cacheControl, /\bs-maxage=[1-9]\d*/);
+      assert.match(cacheControl, /\bstale-while-revalidate=[1-9]\d*/);
       // max-age=0: endpoint changes propagate as soon as the CDN copy expires.
       assert.match(cacheControl, /\bmax-age=0\b/);
     });
@@ -66,8 +74,14 @@ describe('OAuth discovery responses are CDN-cacheable', () => {
     // MCP responses are per-caller; a CDN-cached copy would replay one
     // caller's response to another. Pin the directive's absence on the
     // catch-all route so it stays out of the shared prelude in api/index.ts.
-    const { req, res, state } = fakeReqRes('POST', '/');
-    await handler(req, res).catch(() => {});
+    // This request carries no credentials, so it is rejected by the pre-flight
+    // (401) rather than reaching the MCP handler. Asserting that status is
+    // what gives the absence check below any weight — without it the test
+    // passes for any request that fails early, including one that never
+    // touched this route at all.
+    const { req, res, state, status } = fakeReqRes('POST', '/');
+    await handler(req, res);
+    assert.equal(status(), 401);
     assert.equal(state['Cache-Control'], undefined);
   });
 });


### PR DESCRIPTION
The `.well-known/oauth-protected-resource` and `.well-known/oauth-authorization-server` documents are static per host, but every fetch currently invokes the serverless function (`x-vercel-cache: MISS` on all of them). MCP clients fetch these on every auth flow, so this is a steady source of unnecessary invocations.

This adds `Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400` to both discovery responses:

- `s-maxage=3600` — Vercel's CDN serves repeat fetches from the edge for an hour.
- `stale-while-revalidate=86400` — expiry revalidates in the background instead of re-serializing invocations.
- `max-age=0` — clients don't cache locally, so a deploy that changes the advertised endpoints propagates as soon as the edge copy expires.

Tests pin the directive onto the two discovery routes and pin it **off** the MCP endpoint itself, whose responses are per-caller and must never be CDN-cached.

Hosted-deployment-only change (`api/index.ts` is not part of the published npm package), so no changeset.