### PR TITLE
feat: support Network Volumes in create-pod

### DIFF
--- a/.changeset/create-pod-network-volume.md
+++ b/.changeset/create-pod-network-volume.md
@@ -1,0 +1,7 @@
+---
+'@runpod/mcp-server': minor
+---
+
+Add a `networkVolumeId` parameter to `create-pod` for attaching an existing Network Volume at `volumeMountPath`. On the v2 REST API this maps to `mounts.network: [{ volumeId, path }]`.
+
+Network Volume requests are rejected before any API call when the mount path is missing or when `volumeInGb` also requests a new persistent volume. When deploying from a template, an explicit Network Volume replaces the template's inherited persistent mount.

--- a/src/_shared/mappers.ts
+++ b/src/_shared/mappers.ts
@@ -29,6 +29,7 @@ interface V1PodParams {
   containerDiskInGb?: number;
   volumeInGb?: number;
   volumeMountPath?: string;
+  networkVolumeId?: string;
   ports?: string[];
   env?: Record<string, string>;
   dataCenterIds?: string[];
@@ -101,8 +102,30 @@ function gpuConfigToV2(
 }
 
 export function mapPodCreateToV2(params: V1PodParams): Record<string, unknown> {
+  const container = containerConfigToV2(params);
+
+  // An existing Network Volume uses the v2 network-mount shape. Keep this
+  // create-only: templates support persistent mounts only, and pod updates have
+  // stricter mount-kind/volume-id immutability rules. The create-pod handler
+  // rejects a missing path or a simultaneous volumeInGb before this mapper runs.
+  // Assigning the whole mounts object also makes an explicit Network Volume
+  // replace a persistent mount inherited from a template during the later merge.
+  if (
+    params.networkVolumeId !== undefined &&
+    params.volumeMountPath !== undefined
+  ) {
+    container.mounts = {
+      network: [
+        {
+          volumeId: params.networkVolumeId,
+          path: params.volumeMountPath,
+        },
+      ],
+    };
+  }
+
   return compact({
-    ...containerConfigToV2(params),
+    ...container,
     name: params.name,
     // Private-image registry credential (v2 ContainerConfig `registry`). When
     // deploying from a template, this spreads over the template's registry, so

--- a/src/tools/pods.ts
+++ b/src/tools/pods.ts
@@ -141,7 +141,7 @@ export function registerPodTools(server: McpServer, rt: ToolRuntime): void {
   // Create Pod
   server.tool(
     'create-pod',
-    'Create a new GPU/CPU pod on Runpod. Pass gpuTypeIds for a GPU pod, or computeType:"CPU" for a CPU pod (CPU pods are served by the v1 API for now). Pass either imageName or templateId (templateId deploys from an existing template — its name, image, start command, ports, env, disk, volume, and registry credential are used as defaults, and any field you also pass explicitly replaces the template value for that field, e.g. passing env replaces the whole env set rather than merging; pass containerRegistryAuthId to override or supply a private-image credential, or an empty string to deploy with none). For full SSH access (including SCP/SFTP/rsync), pass sshPublicKey — it sets the PUBLIC_KEY env var and exposes 22/tcp, which official Runpod images turn into a running sshd with the key authorized. If the user specifies neither an image nor a template, recommend the "Runpod Pytorch 2.8.0" image (runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404) as the default — it has the most up-to-date CUDA and PyTorch versions.',
+    'Create a new GPU/CPU pod on Runpod. Pass gpuTypeIds for a GPU pod, or computeType:"CPU" for a CPU pod (CPU pods are served by the v1 API for now). Pass either imageName or templateId (templateId deploys from an existing template — its name, image, start command, ports, env, disk, volume, and registry credential are used as defaults, and any field you also pass explicitly replaces the template value for that field, e.g. passing env replaces the whole env set rather than merging; pass containerRegistryAuthId to override or supply a private-image credential, or an empty string to deploy with none). To attach an existing Network Volume, pass networkVolumeId together with volumeMountPath; do not also pass volumeInGb. An explicit Network Volume replaces a persistent mount inherited from a template. For full SSH access (including SCP/SFTP/rsync), pass sshPublicKey — it sets the PUBLIC_KEY env var and exposes 22/tcp, which official Runpod images turn into a running sshd with the key authorized. If the user specifies neither an image nor a template, recommend the "Runpod Pytorch 2.8.0" image (runpod/pytorch:1.0.2-cu1281-torch280-ubuntu2404) as the default — it has the most up-to-date CUDA and PyTorch versions.',
     {
       name: z
         .string()
@@ -191,6 +191,13 @@ export function registerPodTools(server: McpServer, rt: ToolRuntime): void {
         .string()
         .optional()
         .describe('Path to mount the volume'),
+      networkVolumeId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          'ID of an existing Network Volume to attach. Requires volumeMountPath and cannot be combined with volumeInGb. On a template deploy, this replaces an inherited persistent mount.'
+        ),
       ports: z
         .array(z.string())
         .optional()
@@ -221,6 +228,25 @@ export function registerPodTools(server: McpServer, rt: ToolRuntime): void {
       // the params that become the request body (v1 mapCreate is identity, so it
       // would leak through) and fold it into the FINAL body via applySshPublicKey.
       const { sshPublicKey, ...podParams } = params;
+
+      // A pod may have a newly allocated persistent mount OR an existing
+      // Network Volume, never both. Network mounts also have no default path in
+      // v2, so fail before any template fetch or pod create request.
+      if (params.networkVolumeId !== undefined) {
+        if (params.volumeInGb !== undefined) {
+          return jsonReply({
+            error:
+              'Pass either volumeInGb for a new persistent volume or networkVolumeId for an existing Network Volume, not both.',
+            status: 400,
+          });
+        }
+        if (!params.volumeMountPath) {
+          return jsonReply({
+            error: 'networkVolumeId requires volumeMountPath.',
+            status: 400,
+          });
+        }
+      }
 
       // Validate and normalize BEFORE any pod exists. Refuses a PRIVATE key
       // before it can reach a pod's env (and every process listing inside the

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -772,6 +772,59 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
     });
   });
 
+  it('create-pod v2 maps an existing Network Volume to mounts.network', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      await handlers.get('create-pod')!({
+        name: 'p',
+        imageName: 'i',
+        gpuTypeIds: ['A100'],
+        networkVolumeId: 'nv_1',
+        volumeMountPath: '/workspace',
+      });
+      const body = JSON.parse(outbound[0].body!);
+      assert.deepEqual(body.mounts, {
+        network: [{ volumeId: 'nv_1', path: '/workspace' }],
+      });
+      assert.equal('networkVolumeId' in body, false);
+      assert.equal('volumeMountPath' in body, false);
+    });
+  });
+
+  it('create-pod rejects networkVolumeId without volumeMountPath before any request', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      const out = (await handlers.get('create-pod')!({
+        name: 'p',
+        imageName: 'i',
+        gpuTypeIds: ['A100'],
+        networkVolumeId: 'nv_1',
+      })) as { content: Array<{ text: string }> };
+      assert.equal(outbound.length, 0);
+      const payload = JSON.parse(out.content[0].text);
+      assert.equal(payload.status, 400);
+      assert.match(payload.error, /requires volumeMountPath/);
+    });
+  });
+
+  it('create-pod rejects simultaneous persistent and Network Volumes before any request', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({ jsonBody: {} });
+      const out = (await handlers.get('create-pod')!({
+        name: 'p',
+        imageName: 'i',
+        gpuTypeIds: ['A100'],
+        volumeInGb: 40,
+        networkVolumeId: 'nv_1',
+        volumeMountPath: '/workspace',
+      })) as { content: Array<{ text: string }> };
+      assert.equal(outbound.length, 0);
+      const payload = JSON.parse(out.content[0].text);
+      assert.equal(payload.status, 400);
+      assert.match(payload.error, /not both/);
+    });
+  });
+
   it('create-pod v2 CPU pod (computeType:"CPU") transparently routes to v1 + flags it', async () => {
     await withV2(async () => {
       const { handlers, outbound } = harness({ jsonBody: { id: 'pod_cpu' } });
@@ -984,6 +1037,30 @@ describe('pod routing under RUNPOD_REST_VERSION=v2', () => {
       assert.equal(body.disk, 100); // caller disk wins
       assert.equal(body.registry, 'cra_override'); // caller registry overrides template's cra_9
       assert.equal(body.args, 'python -u handler.py'); // untouched template field stays
+    });
+  });
+
+  it('create-pod v2 Network Volume replaces a persistent mount inherited from a template', async () => {
+    await withV2(async () => {
+      const { handlers, outbound } = harness({
+        jsonBodies: [
+          {
+            ...TEMPLATE_JSON,
+            mounts: { persistent: { size: 40, path: '/template-data' } },
+          },
+          { id: 'pod_new' },
+        ],
+      });
+      await handlers.get('create-pod')!({
+        templateId: 'tpl_1',
+        gpuTypeIds: ['A100'],
+        networkVolumeId: 'nv_1',
+        volumeMountPath: '/workspace',
+      });
+      const body = JSON.parse(outbound[1].body!);
+      assert.deepEqual(body.mounts, {
+        network: [{ volumeId: 'nv_1', path: '/workspace' }],
+      });
     });
   });
 

--- a/tests/mappers.test.ts
+++ b/tests/mappers.test.ts
@@ -50,6 +50,34 @@ describe('mapPodCreateToV2', () => {
     );
   });
 
+  it('networkVolumeId/volumeMountPath → mounts.network[{volumeId,path}]', () => {
+    const out = mapPodCreateToV2({
+      networkVolumeId: 'nv_1',
+      volumeMountPath: '/workspace',
+    });
+    assert.deepEqual(out.mounts, {
+      network: [{ volumeId: 'nv_1', path: '/workspace' }],
+    });
+  });
+
+  it('networkVolumeId without volumeMountPath → NO mounts', () => {
+    assert.equal(
+      'mounts' in mapPodCreateToV2({ networkVolumeId: 'nv_1' }),
+      false
+    );
+  });
+
+  it('an explicit network mount replaces the persistent mapper output', () => {
+    const out = mapPodCreateToV2({
+      volumeInGb: 30,
+      networkVolumeId: 'nv_1',
+      volumeMountPath: '/workspace',
+    });
+    assert.deepEqual(out.mounts, {
+      network: [{ volumeId: 'nv_1', path: '/workspace' }],
+    });
+  });
+
   it('gpuTypeIds[] → gpu.id (array→scalar) + gpuCount → gpu.count', () => {
     const out = mapPodCreateToV2({ gpuTypeIds: ['A', 'B'], gpuCount: 4 });
     assert.deepEqual(out.gpu, { id: 'A', count: 4 });


### PR DESCRIPTION
## Summary

- add `networkVolumeId` to the `create-pod` tool
- map existing Network Volumes to the v2 REST shape `mounts.network: [{ volumeId, path }]`
- reject missing mount paths and persistent/Network Volume conflicts before any API request
- let an explicit Network Volume replace a persistent mount inherited from a template
- add mapper, handler, template-override, and validation coverage plus a changeset

## Validation

- `pnpm test` — 695 passed, 8 opt-in live tests skipped
- `pnpm type-check`
- `pnpm lint`
- `tsup --tsconfig tsconfig.build.json`
- Prettier check on all changed TypeScript files